### PR TITLE
README rework + setup bugfix

### DIFF
--- a/ADVANCED_SETUP.md
+++ b/ADVANCED_SETUP.md
@@ -1,0 +1,100 @@
+# Advanced Setup
+
+## Launching a new node from scratch
+
+### Setting environment varaibles
+
+```sh
+audius-cli set-config <service-name> <key> <value>
+```
+
+#### Creator Node
+The full list of variables and explanations can be found on the wiki [here](https://github.com/AudiusProject/audius-protocol/wiki/Content-Node:-Configuration-Details#required-environment-variables).
+
+Some variables must be set, you can do this with the following command:
+```sh
+audius-cli set-config --required creator-node
+```
+
+Currently this breaks down into,
+
+```sh
+audius-cli set-config creator-node
+key   : spOwnerWallet
+value : <address of wallet that contains audius tokens>
+
+audius-cli set-config creator-node
+key   : delegateOwnerWallet
+value : <address of wallet that contains no tokens but that is registered on chain>
+
+audius-cli set-config creator-node
+key   : delegatePrivateKey
+value : <private key>
+
+audius-cli set-config creator-node
+key   : creatorNodeEndpoint
+value : <your service url>
+```
+**Note:** if you haven't registered the service yet, please enter the url you plan to register for `creatorNodeEndpoint`.
+
+#### Discovery Provider
+```sh
+audius-cli set-config discovery-provider
+key   : audius_delegate_owner_wallet
+value : <delegate_owner_wallet>
+
+audius-cli set-config discovery-provider
+key   : audius_delegate_private_key
+value : <delegate_private_key>
+```
+
+If you are using an external managed Postgres database (version 11.1+), replace the db url with,
+```sh
+audius-cli set-config discovery-provider backend
+key   : audius_db_url
+value : <audius_db_url>
+
+audius-cli set-config discovery-provider backend
+key   : audius_db_url_read_replica
+value : <audius_db_url_read_replica>
+```
+
+**Note:** If there's no read replica, enter the primary db url for both env vars.
+
+The below is only if using a managed posgres database:
+
+In the managed postgres database and set the `temp_file_limit` flag to `2147483647` and run the following SQL command on the destination db.
+```
+CREATE EXTENSION pg_trgm;
+```
+
+Make sure that your service exposes all the required environment variables. See wiki [here](https://github.com/AudiusProject/audius-protocol/wiki/Discovery-Node:-Configuration-Details#required-environment-variables) for full list of env vars and descriptions.
+
+### Launch
+```sh
+audius-cli launch <service-name>
+
+# Options:
+# --seed
+#     Seeds the database from a snapshot. Required for first-time discovery setup.
+```
+
+## Migration from Kubernetes
+
+For existing machines running audius services via kube, first run the following commands,
+```sh
+audius-cli auto-upgrade --remove
+kubectl delete --all-namespaces --all deployments
+kubectl delete --all-namespaces --all pods
+sudo kubeadm reset
+
+git clone https://github.com/AudiusProject/audius-docker-compose.git ~/audius-docker-compose
+cd ~/audius-docker-compose
+bash setup.sh
+```
+
+Following this, you will have to reset the keys from before, you can preview old keys with,
+```
+cat audius-k8s-manifests/config.yaml
+```
+and set them similarly to before with audius-cli

--- a/README.md
+++ b/README.md
@@ -1,115 +1,16 @@
 # Audius Docker Compose
 
-Launch audius services via docker compose
+Launch Audius services using docker-compose. Minimum system requirements:
 
-Tested on Ubuntu 20.04 LTS
+Ubuntu 20.04 LTS
+8 vCPU (16 core recommended)
+16 GB RAM (32 recommended)
+250 GB SSD for discovery-provider or 2TB SSD for creator-node
 
-## Migration from Kubernetes
-
-For existing machines running audius services via kube, first run the following commands,
-```sh
-audius-cli auto-upgrade --remove
-kubectl delete --all-namespaces --all deployments
-kubectl delete --all-namespaces --all pods
-sudo kubeadm reset
-
-git clone https://github.com/AudiusProject/audius-docker-compose.git ~/audius-docker-compose
-cd ~/audius-docker-compose
-bash setup.sh
-```
-
-Following this, you will have to reset the keys from before, you can preview old keys with,
-```
-cat audius-k8s-manifests/config.yaml
-```
-and set them similarly to before with audius-cli
-
-## Single Click Install
+## Installation
 
 ```sh
 bash <(curl https://raw.githubusercontent.com/AudiusProject/audius-docker-compose/main/install.sh)
 ```
 
-## Launching an Audius Service
-
-```sh
-bash setup.sh
-```
-
-### Setting Keys
-
-For every key do
-```sh
-audius-cli set-config <service-name> <key> <value>
-```
-
-#### Creator Node
-The full list of variables and explanations can be found on the wiki [here](https://github.com/AudiusProject/audius-protocol/wiki/Content-Node:-Configuration-Details#required-environment-variables).
-
-Some variables must be set, you can do this with the following command:
-```sh
-audius-cli set-config --required creator-node
-```
-
-Currently this breaks down into,
-
-```sh
-audius-cli set-config creator-node
-key   : spOwnerWallet
-value : <address of wallet that contains audius tokens>
-
-audius-cli set-config creator-node
-key   : delegateOwnerWallet
-value : <address of wallet that contains no tokens but that is registered on chain>
-
-audius-cli set-config creator-node
-key   : delegatePrivateKey
-value : <private key>
-
-audius-cli set-config creator-node
-key   : creatorNodeEndpoint
-value : <your service url>
-```
-**Note:** if you haven't registered the service yet, please enter the url you plan to register for `creatorNodeEndpoint`.
-
-#### Discovery Provider
-```sh
-audius-cli set-config discovery-provider
-key   : audius_delegate_owner_wallet
-value : <delegate_owner_wallet>
-
-audius-cli set-config discovery-provider
-key   : audius_delegate_private_key
-value : <delegate_private_key>
-```
-
-If you are using an external managed Postgres database (version 11.1+), replace the db url with,
-```sh
-audius-cli set-config discovery-provider backend
-key   : audius_db_url
-value : <audius_db_url>
-
-audius-cli set-config discovery-provider backend
-key   : audius_db_url_read_replica
-value : <audius_db_url_read_replica>
-```
-
-**Note:** If there's no read replica, enter the primary db url for both env vars.
-
-The below is only if using a managed posgres database:
-
-In the managed postgres database and set the `temp_file_limit` flag to `2147483647` and run the following SQL command on the destination db.
-```
-CREATE EXTENSION pg_trgm;
-```
-
-Make sure that your service exposes all the required environment variables. See wiki [here](https://github.com/AudiusProject/audius-protocol/wiki/Discovery-Node:-Configuration-Details#required-environment-variables) for full list of env vars and descriptions.
-
-### Launch
-```sh
-audius-cli launch <service-name>
-
-# Options:
-# --seed
-#     Seeds the database from a snapshot. Required for first-time discovery setup.
-```
+For more advanced configuration options or migrating from Kubernetes check out the [Advanced Setup Guide](https://github.com/AudiusProject/audius-docker-compose/blob/main/ADVANCED_SETUP.md)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Launch Audius services using docker-compose. Minimum system requirements:
 
-Ubuntu 20.04 LTS
-8 vCPU (16 core recommended)
-16 GB RAM (32 recommended)
-250 GB SSD for discovery-provider or 2TB SSD for creator-node
+- Ubuntu 20.04 LTS
+- 8 vCPU (16 core recommended)
+- 16 GB RAM (32 recommended)
+- 250 GB SSD for discovery-provider or 2TB SSD for creator-node
 
 ## Installation
 
@@ -13,4 +13,4 @@ Ubuntu 20.04 LTS
 bash <(curl https://raw.githubusercontent.com/AudiusProject/audius-docker-compose/main/install.sh)
 ```
 
-For more advanced configuration options or migrating from Kubernetes check out the [Advanced Setup Guide](https://github.com/AudiusProject/audius-docker-compose/blob/main/ADVANCED_SETUP.md)
+For more advanced configuration options or migrating from Kubernetes check out the [Advanced Setup Guide](ADVANCED_SETUP.md)

--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ Launch Audius services using docker-compose. Minimum system requirements:
 bash <(curl https://raw.githubusercontent.com/AudiusProject/audius-docker-compose/main/install.sh)
 ```
 
+## More options
 For more advanced configuration options or migrating from Kubernetes check out the [Advanced Setup Guide](ADVANCED_SETUP.md)

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,8 @@
 set -e
 
 git clone https://github.com/AudiusProject/audius-docker-compose.git ~/audius-docker-compose
+cd audius-docker-compose/
+git checkout dm-readme-rework
 
 while read -p "Service to install (creator-node, discovery-provider): "; do
     if [[ $REPLY =~ ^(creator-node|discovery-provider)$ ]]; then
@@ -10,4 +12,4 @@ while read -p "Service to install (creator-node, discovery-provider): "; do
     echo "Invalid service name"
 done
 
-~/audius-docker-compose/setup.sh $REPLY
+./setup.sh $REPLY

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,6 @@
 set -e
 
 git clone https://github.com/AudiusProject/audius-docker-compose.git ~/audius-docker-compose
-cd audius-docker-compose/
-git checkout dm-readme-rework
 
 while read -p "Service to install (creator-node, discovery-provider): "; do
     if [[ $REPLY =~ ^(creator-node|discovery-provider)$ ]]; then
@@ -12,4 +10,4 @@ while read -p "Service to install (creator-node, discovery-provider): "; do
     echo "Invalid service name"
 done
 
-./setup.sh $REPLY
+~/audius-docker-compose/setup.sh $REPLY

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set -x
+# set -x
 
 # set current directory to script directory
 cd "$(dirname "$0")"
@@ -32,6 +32,7 @@ EOF
 
 # allow current user to use docker without sudo
 sudo usermod -aG docker $USER
+sudo chmod 666 /var/run/docker.sock
 
 # install docker-compose
 DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}


### PR DESCRIPTION
Move everything besides single line install into another README and fix a bug where setup.sh calling docker command fails with ```Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/containers/json?all=1&filters=%7B%22label%22%3A%7B%22com.docker.compose.project%3Ddiscovery-provider%22%3Atrue%7D%7D&limit=0": dial unix /var/run/docker.sock: connect: permission denied
