### PR TITLE
Use Logspout to forward logs to Loggly

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -299,10 +299,10 @@ def set_config(ctx, service, unset, required, key, value):
                         override_env_data.get(key, env_data.get(key)),
                     ),
                 )
-                if key == "logglyTags":
-                    loggly_tags = dotenv.get_key(override_env, key)
-                    loggly_env = ctx.obj["manifests_path"] / "override.env"
-                    dotenv.set_key(loggly_env, key, loggly_tags)
+                # if key == "logglyTags":
+                #     loggly_tags = dotenv.get_key(override_env, key)
+                #     loggly_env = ctx.obj["manifests_path"] / "override.env"
+                #     dotenv.set_key(loggly_env, key, loggly_tags)
             if unset and value == "":
                 dotenv.unset_key(override_env, key)
     else:

--- a/audius-cli
+++ b/audius-cli
@@ -299,10 +299,6 @@ def set_config(ctx, service, unset, required, key, value):
                         override_env_data.get(key, env_data.get(key)),
                     ),
                 )
-                # if key == "logglyTags":
-                #     loggly_tags = dotenv.get_key(override_env, key)
-                #     loggly_env = ctx.obj["manifests_path"] / "override.env"
-                #     dotenv.set_key(loggly_env, key, loggly_tags)
             if unset and value == "":
                 dotenv.unset_key(override_env, key)
     else:

--- a/audius-cli
+++ b/audius-cli
@@ -299,6 +299,10 @@ def set_config(ctx, service, unset, required, key, value):
                         override_env_data.get(key, env_data.get(key)),
                     ),
                 )
+                if key == "logglyTags":
+                    loggly_tags = dotenv.get_key(override_env, key)
+                    loggly_env = ctx.obj["manifests_path"] / "override.env"
+                    dotenv.set_key(loggly_env, key, loggly_tags)
             if unset and value == "":
                 dotenv.unset_key(override_env, key)
     else:

--- a/common-services.yml
+++ b/common-services.yml
@@ -18,12 +18,6 @@ services:
   logspout:
     image: audius/logspout:v3.2.14
     container_name: logspout
-    env_file:
-      # requires audius-cli change
-      # - override.env
-      # we can try both overrides and one SHOULD be empty and the other should have what we need
-      - creator-node/override.env
-      - discovery-provider/override.env
     restart: always
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/common-services.yml
+++ b/common-services.yml
@@ -22,7 +22,11 @@ services:
       - SYSLOG_STRUCTURED_DATA=${LOGGLY_TOKEN}@41058 tag="logspout"
       - BACKLOG=false
     env_file:
+      # requires audius-cli change
       - override.env
+      # we can try both overrides and one SHOULD be empty and the other should have what we need
+      - creator-node/override.env
+      - discovery-provider/override.env
     command: multiline+syslog+tcp://logs-01.loggly.com:514
     restart: always
     volumes:

--- a/common-services.yml
+++ b/common-services.yml
@@ -16,18 +16,14 @@ services:
       timeout: 5s
 
   logspout:
-    image: gliderlabs/logspout:v3.2.14
+    image: audius/logspout:v3.2.14
     container_name: logspout
-    environment:
-      - SYSLOG_STRUCTURED_DATA=${LOGGLY_TOKEN}@41058 tag="logspout"
-      - BACKLOG=false
     env_file:
       # requires audius-cli change
-      - override.env
+      # - override.env
       # we can try both overrides and one SHOULD be empty and the other should have what we need
       - creator-node/override.env
       - discovery-provider/override.env
-    command: multiline+syslog+tcp://logs-01.loggly.com:514
     restart: always
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/common-services.yml
+++ b/common-services.yml
@@ -14,3 +14,16 @@ services:
       test: ["CMD", "redis-cli", "PING"]
       interval: 10s
       timeout: 5s
+
+  logspout:
+    image: gliderlabs/logspout:v3.2.14
+    container_name: logspout
+    environment:
+      - SYSLOG_STRUCTURED_DATA=${LOGGLY_TOKEN}@41058 tag="logspout"
+      - BACKLOG=false
+    env_file:
+      - override.env
+    command: multiline+syslog+tcp://logs-01.loggly.com:514
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -18,6 +18,15 @@ services:
     extends:
       file: ../common-services.yml
       service: base-cache
+    env_file:
+      - override.env
+    networks:
+      - creator-node-network
+
+  logspout:
+    extends:
+      file: ../common-services.yml
+      service: logspout
     networks:
       - creator-node-network
 

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -18,8 +18,6 @@ services:
     extends:
       file: ../common-services.yml
       service: base-cache
-    env_file:
-      - override.env
     networks:
       - creator-node-network
 

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     extends:
       file: ../common-services.yml
       service: logspout
+    env_file:
+      - override.env
     networks:
       - creator-node-network
 

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -23,6 +23,15 @@ services:
     networks:
       - discovery-provider-network
 
+  logspout:
+    extends:
+      file: ../common-services.yml
+      service: logspout
+    env_file:
+      - override.env
+    networks:
+      - discovery-provider-network
+
   elasticsearch:
     container_name: elasticsearch
     image: docker.elastic.co/elasticsearch/elasticsearch:8.1.0


### PR DESCRIPTION
Add our custom-built logspout sidecar container for forwarding logs to Loggly.

Sister PR that builds the image can be found here: https://github.com/AudiusProject/audius-protocol/pull/3124