### PR TITLE
Set user for postgres to postgres

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -2,6 +2,7 @@ services:
   base-db:
     image: postgres:11.4
     command: postgres -c shared_buffers=512MB -c max_connections=500 -c shared_preload_libraries=pg_stat_statements
+    user: postgres
     healthcheck:
       test: ["CMD", "pg_isready"]
       interval: 10s


### PR DESCRIPTION
Doing `docker logs -f postgres` you see a lot of:

```
2022-06-03 01:05:03.404 UTC [29416] FATAL:  role "root" does not exist
2022-06-03 01:05:13.507 UTC [29426] FATAL:  role "root" does not exist
```

Based on [this answer](https://stackoverflow.com/a/67865761) one fix is to run as user `postgres`