### PR TITLE
Disable snapback, enable refactored state machine

### DIFF
--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -23,6 +23,7 @@ logLevel=info
 maxAudioFileSizeBytes=1000000000
 pinAddCIDs=QmXSa6NxfA3e2hCpd8P5gNnZJs9PjZ3yGDHiRHR5B7Rq52,QmNU5Sv8se1aqfUFYFxupX1wdZfGTGnJp6vpoMbLNceGVi
 setTimeout=3600000
+snapbackHighestReconfigMode=RECONFIG_DISABLED
 stateMonitoringQueueRateLimitInterval=60000
 stateMonitoringQueueRateLimitJobsPerInterval=3
 timeout=3600000

--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -9,6 +9,7 @@ redisPort=6379
 dataNetworkId=99
 dataProviderUrl=https://poa-gateway.audius.co
 dataRegistryAddress=0xC611C82150b56E6e4Ec5973AcAbA8835Dd0d75A2
+disableSnapback=true
 enableRsyslog=false
 ethNetworkId=1
 ethOwnerWallet=0xe886a1858d2d368ef8f02c65bdd470396a1ab188
@@ -22,10 +23,9 @@ logLevel=info
 maxAudioFileSizeBytes=1000000000
 pinAddCIDs=QmXSa6NxfA3e2hCpd8P5gNnZJs9PjZ3yGDHiRHR5B7Rq52,QmNU5Sv8se1aqfUFYFxupX1wdZfGTGnJp6vpoMbLNceGVi
 setTimeout=3600000
-timeout=3600000
-disableSnapback=true
 stateMonitoringQueueRateLimitInterval=60000
 stateMonitoringQueueRateLimitJobsPerInterval=3
+timeout=3600000
 
 # required values
 creatorNodeEndpoint=

--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -23,6 +23,9 @@ maxAudioFileSizeBytes=1000000000
 pinAddCIDs=QmXSa6NxfA3e2hCpd8P5gNnZJs9PjZ3yGDHiRHR5B7Rq52,QmNU5Sv8se1aqfUFYFxupX1wdZfGTGnJp6vpoMbLNceGVi
 setTimeout=3600000
 timeout=3600000
+disableSnapback=true
+stateMonitoringQueueRateLimitInterval=60000
+stateMonitoringQueueRateLimitJobsPerInterval=3
 
 # required values
 creatorNodeEndpoint=

--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -24,6 +24,9 @@ pinAddCIDs=Qma5FGErNqHA32cyEjgp8hnwCFoqyYcBXU1ySKPA6MUJS5,QmYPy9A3zxLeBBuk1vpPNe
 setTimeout=3600000
 snapbackMaxLastSuccessfulRunDelayMs=18000000 # 5hrs in ms
 timeout=3600000
+disableSnapback=true
+stateMonitoringQueueRateLimitInterval=60000
+stateMonitoringQueueRateLimitJobsPerInterval=3
 
 # required values
 creatorNodeEndpoint=

--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -9,6 +9,7 @@ redisPort=6379
 dataNetworkId=77
 dataProviderUrl=https://poa-gateway.staging.audius.co
 dataRegistryAddress=0x793373aBF96583d5eb71a15d86fFE732CD04D452
+disableSnapback=true
 enableRsyslog=false
 ethNetworkId=3
 ethOwnerWallet=0xcccc7428648c4AdC0ae262D3547584dDAE25c465
@@ -23,10 +24,9 @@ maxAudioFileSizeBytes=1000000000
 pinAddCIDs=Qma5FGErNqHA32cyEjgp8hnwCFoqyYcBXU1ySKPA6MUJS5,QmYPy9A3zxLeBBuk1vpPNeG5aoMfa5qLNjJgh473Z9zV9b
 setTimeout=3600000
 snapbackMaxLastSuccessfulRunDelayMs=18000000 # 5hrs in ms
-timeout=3600000
-disableSnapback=true
 stateMonitoringQueueRateLimitInterval=60000
 stateMonitoringQueueRateLimitJobsPerInterval=3
+timeout=3600000
 
 # required values
 creatorNodeEndpoint=

--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -23,6 +23,7 @@ logLevel=info
 maxAudioFileSizeBytes=1000000000
 pinAddCIDs=Qma5FGErNqHA32cyEjgp8hnwCFoqyYcBXU1ySKPA6MUJS5,QmYPy9A3zxLeBBuk1vpPNeG5aoMfa5qLNjJgh473Z9zV9b
 setTimeout=3600000
+snapbackHighestReconfigMode=RECONFIG_DISABLED
 snapbackMaxLastSuccessfulRunDelayMs=18000000 # 5hrs in ms
 stateMonitoringQueueRateLimitInterval=60000
 stateMonitoringQueueRateLimitJobsPerInterval=3


### PR DESCRIPTION
Changes config defaults to disable snapback and enable the refactored state machine at a rate of 3 monitoring jobs per minute. Note that this change doesn't stop the manual sync queue, which snapback will continue to run regardless of the config options. See https://github.com/AudiusProject/audius-protocol/pull/3317.