### PR TITLE
Add non-blocking logs

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -8,6 +8,7 @@ services:
       timeout: 5s
     ports:
       - "5432:5432"
+    logging: *default-logging
 
   base-cache:
     image: redis:5.0.5
@@ -16,6 +17,7 @@ services:
       test: ["CMD", "redis-cli", "PING"]
       interval: 10s
       timeout: 5s
+    logging: *default-logging
 
   logspout:
     image: audius/logspout:v3.2.14
@@ -23,3 +25,12 @@ services:
     restart: always
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    logging: *default-logging
+
+x-logging: &default-logging
+  options:
+    max-size: 10m
+    max-file: 3
+    mode: non-blocking
+    max-buffer-size: 4m
+  driver: json-file

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - /var/k8s/discovery-provider-db:/var/lib/postgresql/data # Use k8s location for backward compatibility
     networks:
       - discovery-provider-network
+    logging: *default-logging
 
   cache:
     container_name: redis
@@ -22,6 +23,7 @@ services:
       service: base-cache
     networks:
       - discovery-provider-network
+    logging: *default-logging
 
   logspout:
     extends:
@@ -31,6 +33,7 @@ services:
       - override.env
     networks:
       - discovery-provider-network
+    logging: *default-logging
 
   elasticsearch:
     container_name: elasticsearch
@@ -60,6 +63,7 @@ services:
         ]
       interval: 10s
       timeout: 5s
+    logging: *default-logging
 
   backend:
     container_name: server
@@ -83,6 +87,7 @@ services:
       - audius_discprov_infra_setup=audius-docker-compose
     networks:
       - discovery-provider-network
+    logging: *default-logging
 
   seed:
     image: audius/discovery-provider:${TAG:-cfea671853e49b09d1e2c6dcff3a7be7c3c037f6}
@@ -99,6 +104,7 @@ services:
       - discovery-provider-network
     profiles:
       - seed
+    logging: *default-logging
 
   autoheal:
     image: willfarrell/autoheal
@@ -108,6 +114,7 @@ services:
     environment:
       - AUTOHEAL_INTERVAL=10
       - CURL_TIMEOUT=30
+    logging: *default-logging
 
 networks:
   discovery-provider-network:


### PR DESCRIPTION
**This PR has not been tested.**

The idea for this PR came when reading these sections:

* https://docs.docker.com/config/containers/logging/configure/#configure-the-delivery-mode-of-log-messages-from-container-to-log-driver
* https://docs.docker.com/compose/compose-file/#fragments

> The non-blocking message delivery mode prevents applications from blocking due to logging back pressure. Applications are likely to fail in unexpected ways when STDERR or STDOUT streams block.

While not an issue now, I figured to call this out early in case it does become an issue since we're running a few microservices and databases on the same node.

If we merge this change today, we would:

* no longer have to write to `/etc/docker/daemon.json`
* would ensure all containers would not block on disk contention when attempting to write logs
* would provide all containers with a 4m log buffer should disk contention occur