### PR TITLE
Explicitly specify postgres user and password in compose config

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -8,6 +8,8 @@ services:
       timeout: 5s
     ports:
       - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: postgres
 
   base-cache:
     image: redis:5.0.5

--- a/common-services.yml
+++ b/common-services.yml
@@ -9,6 +9,7 @@ services:
     ports:
       - "5432:5432"
     environment:
+      POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
 
   base-cache:


### PR DESCRIPTION
According to the docker postgres [README](https://hub.docker.com/_/postgres), the only required env var is POSTGRES_PASSWORD, which we don't specify. Discovered by reading this Github issue https://github.com/sameersbn/docker-postgresql/issues/112.

Not sure if this is what's causing the db corruption / inability to connect, but we should specify this anyway.

Some other things to try
https://stackoverflow.com/a/55668376/11240376

EDIT
More docs supporting this theory. This [docker entrypoint script](https://github.com/docker-library/postgres/blob/74e51d102aede317665f2b4a9b89362135402fe7/11/alpine/docker-entrypoint.sh#L91) calls initdb and in the [docs](https://www.postgresql.org/docs/current/app-initdb.html) it says -U is the name of the superuser and it defaults to the effective user running initdb, which inside docker should be postgres? but specifying for good measure