### PR TITLE
Default write quorum to staging=true, prod=false

### DIFF
--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -27,6 +27,7 @@ snapbackHighestReconfigMode=RECONFIG_DISABLED
 stateMonitoringQueueRateLimitInterval=60000
 stateMonitoringQueueRateLimitJobsPerInterval=3
 timeout=3600000
+enforceWriteQuorum=false
 
 # required values
 creatorNodeEndpoint=

--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -29,6 +29,7 @@ snapbackMaxLastSuccessfulRunDelayMs=18000000 # 5hrs in ms
 stateMonitoringQueueRateLimitInterval=60000
 stateMonitoringQueueRateLimitJobsPerInterval=3
 timeout=3600000
+enforceWriteQuorum=true
 
 # required values
 creatorNodeEndpoint=


### PR DESCRIPTION
For rollout, write quorum should default to off on prod because we want to be able to turn write quorum on/off via Optimizely. If the write quorum env var defaults to true on prod, then we won't be able to turn it off in an emergency without waiting for SPs to update. For staging we want to test it as on by default.