### PR TITLE
Lock postgres port down only to host

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -7,7 +7,7 @@ services:
       interval: 10s
       timeout: 5s
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Port 5432 is publicly accessible from outside the VM, we can lock it down by specifying only the host. Docs https://docs.docker.com/engine/reference/commandline/run/#publish-or-expose-port--p---expose