### PR TITLE
Re-enable "Make audius_discprov_url required and add blurb about logging"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,12 @@ This folder contains a set of scripts and utilities to manage services like:
 - Delist content scripts (for content node)
 - Automatic rewards claim script
 
+## Logging
+Logging is enabled by default to stream logs to a logging service for ease of debugging. It's strongly recommended to keep logging enabled. However, if there's a reason to turn logging off, it can be disabled with:
+ ```
+ audius-cli set-config creator-node|discovery-node audius_loggly_disable true
+ audius-cli launch creator-node|discovery-node
+ ```
+
 ## More options
 For more advanced configuration options or migrating from Kubernetes check out the [Advanced Setup Guide](ADVANCED_SETUP.md)

--- a/common-services.yml
+++ b/common-services.yml
@@ -21,7 +21,7 @@ services:
       timeout: 5s
 
   logspout:
-    image: audius/logspout:v3.2.14
+    image: audius/logspout:v3.2.14-1
     container_name: logspout
     restart: always
     volumes:

--- a/discovery-provider/prod.env
+++ b/discovery-provider/prod.env
@@ -38,3 +38,4 @@ audius_web3_port=443
 # required values
 audius_delegate_owner_wallet=
 audius_delegate_private_key=
+audius_discprov_url=

--- a/discovery-provider/stage.env
+++ b/discovery-provider/stage.env
@@ -38,3 +38,4 @@ audius_web3_port=443
 # required values
 audius_delegate_owner_wallet=
 audius_delegate_private_key=
+audius_discprov_url=


### PR DESCRIPTION
Reverts AudiusProject/audius-docker-compose#51 and re-enables AudiusProject/audius-docker-compose#50