### PR TITLE
Add entity manager address for prod/stage DP

### DIFF
--- a/discovery-provider/prod.env
+++ b/discovery-provider/prod.env
@@ -6,6 +6,7 @@ audius_db_url=postgresql://postgres:postgres@db:5432/audius_discovery
 audius_db_url_read_replica=postgresql://postgres:postgres@db:5432/audius_discovery
 
 audius_contracts_registry=0xC611C82150b56E6e4Ec5973AcAbA8835Dd0d75A2
+audius_contracts_entity_manager_address=0x2F99338637F027CFB7494E46B49987457beCC6E3
 audius_cors_allow_all=true
 audius_discprov_blacklist_block_processing_window=1200
 audius_discprov_block_processing_window=100

--- a/discovery-provider/stage.env
+++ b/discovery-provider/stage.env
@@ -6,6 +6,7 @@ audius_db_url=postgresql://postgres:postgres@db:5432/audius_discovery
 audius_db_url_read_replica=postgresql://postgres:postgres@db:5432/audius_discovery
 
 audius_contracts_registry=0x793373aBF96583d5eb71a15d86fFE732CD04D452
+audius_contracts_entity_manager_address=0x2F99338637F027CFB7494E46B49987457beCC6E3
 audius_cors_allow_all=true
 audius_discprov_blacklist_block_processing_window=1200
 audius_discprov_block_processing_window=100


### PR DESCRIPTION
Add entity manager contract address. 

https://www.notion.so/audiusproject/8-5-22-Deploy-EntityManager-Contract-4c0f287d717a41fbb3e15120d684782d

Contract deployed 
Prod: https://blockscout.com/poa/core/address/0x2F99338637F027CFB7494E46B49987457beCC6E3
Stage: https://blockscout.com/poa/sokol/address/0x2F99338637F027CFB7494E46B49987457beCC6E3

Note: it's the same address because it's deterministically computed https://ethereum.stackexchange.com/questions/760/how-is-the-address-of-an-ethereum-contract-computed