### PR TITLE
Update discovery node to c54dc4

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -63,7 +63,7 @@ services:
 
   backend:
     container_name: server
-    image: audius/discovery-provider:${TAG:-046808de17bc10aba88e5f1eb04e10c92f2afe45}
+    image: audius/discovery-provider:${TAG:-c54dc44721ad3c8352f0cec56b94002cffe9512a}
     restart: always
     depends_on:
       db:
@@ -85,7 +85,7 @@ services:
       - discovery-provider-network
 
   seed:
-    image: audius/discovery-provider:${TAG:-046808de17bc10aba88e5f1eb04e10c92f2afe45}
+    image: audius/discovery-provider:${TAG:-c54dc44721ad3c8352f0cec56b94002cffe9512a}
     command: bash /usr/share/seed.sh ${NETWORK:-prod}
     env_file:
       - ${NETWORK:-prod}.env


### PR DESCRIPTION
c54dc44721ad3c8352f0cec56b94002cffe9512a
is the head of release 0.3.65 (https://github.com/AudiusProject/audius-protocol/tree/release-v0.3.65)
which includes two critical fixes:
- an N+1 query fix
- a fix to remove caching that was incorrectly populating repost counts