### PR TITLE
Remove stage CN snapbackHighestReconfigMode envvar

### DIFF
--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -24,7 +24,6 @@ logLevel=info
 maxAudioFileSizeBytes=1000000000
 pinAddCIDs=Qma5FGErNqHA32cyEjgp8hnwCFoqyYcBXU1ySKPA6MUJS5,QmYPy9A3zxLeBBuk1vpPNeG5aoMfa5qLNjJgh473Z9zV9b
 setTimeout=3600000
-snapbackHighestReconfigMode=RECONFIG_DISABLED
 snapbackMaxLastSuccessfulRunDelayMs=18000000 # 5hrs in ms
 stateMonitoringQueueRateLimitInterval=60000
 stateMonitoringQueueRateLimitJobsPerInterval=1


### PR DESCRIPTION
Will instead use value set in CN config.js (https://github.com/AudiusProject/audius-protocol/blob/master/creator-node/src/config.js#L418)
Has been working so far on staging bc literally every node has overridden this value manually 🤦 