### PR TITLE
Add OpenTelemetry Env Vars

### DIFF
--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -28,6 +28,8 @@ stateMonitoringQueueRateLimitInterval=60000
 stateMonitoringQueueRateLimitJobsPerInterval=1
 timeout=3600000
 enforceWriteQuorum=false
+otelTracingEnabled=true
+otelCollectorUrl=https://opentelemetry-collector.audius.co/v1/traces
 
 # required values
 creatorNodeEndpoint=

--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -34,6 +34,8 @@ recoverOrphanedDataQueueRateLimitJobsPerInterval=1
 maxUpdateReplicaSetJobConcurrency=25
 maxRecurringRequestSyncJobConcurrency=50
 snapbackUsersPerJob=2000
+otelTracingEnabled=true
+otelCollectorUrl=https://opentelemetry-collector.staging.audius.co/v1/traces
 
 # required values
 creatorNodeEndpoint=


### PR DESCRIPTION
This PR adds the env vars for enabled opentelemetry tracing as well as for exporting data to out collector