### PR TITLE
Unset snapbackHighestReconfigMode for prod CN

### DIFF
--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -23,7 +23,6 @@ logLevel=info
 maxAudioFileSizeBytes=1000000000
 pinAddCIDs=QmXSa6NxfA3e2hCpd8P5gNnZJs9PjZ3yGDHiRHR5B7Rq52,QmNU5Sv8se1aqfUFYFxupX1wdZfGTGnJp6vpoMbLNceGVi
 setTimeout=3600000
-snapbackHighestReconfigMode=RECONFIG_DISABLED
 stateMonitoringQueueRateLimitInterval=60000
 stateMonitoringQueueRateLimitJobsPerInterval=1
 timeout=3600000


### PR DESCRIPTION
Instead this will default to the value set in CN config.js