### PR TITLE
Bump SP snapbackUsersPerJob

### DIFF
--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -33,7 +33,7 @@ maxUpdateReplicaSetJobConcurrency=5
 maxRecurringRequestSyncJobConcurrency=10
 mergePrimaryAndSecondaryEnabled=false
 snapbackHighestReconfigMode=PRIMARY_AND_OR_SECONDARIES
-snapbackUsersPerJob=1000
+snapbackUsersPerJob=1500
 
 # required values
 creatorNodeEndpoint=


### PR DESCRIPTION
SP queues are mostly empty (on avg they have 1 active job, out of 5 possible jobs for reconfig) [see grafana panel](http://grafana.audius.co/d/3VPUdqZVz/audius-content-node-bull-queue?orgId=1&refresh=30m&from=1663282062775&to=1663303602775&var-env=prod&var-host=audius-content-1.cultur3stake.com&var-host=audius-content-10.cultur3stake.com&var-host=audius-content-11.cultur3stake.com&var-host=audius-content-12.cultur3stake.com&var-host=audius-content-13.cultur3stake.com&var-host=audius-content-14.cultur3stake.com&var-host=audius-content-15.cultur3stake.com&var-host=audius-content-16.cultur3stake.com&var-host=audius-content-17.cultur3stake.com&var-host=audius-content-18.cultur3stake.com&var-host=audius-content-2.cultur3stake.com&var-host=audius-content-3.cultur3stake.com&var-host=audius-content-4.cultur3stake.com&var-host=audius-content-5.cultur3stake.com&var-host=audius-content-6.cultur3stake.com&var-host=audius-content-7.cultur3stake.com&var-host=audius-content-8.cultur3stake.com&var-host=audius-content-9.cultur3stake.com&var-host=blockdaemon-audius-content-01.bdnodes.net&var-host=blockdaemon-audius-content-02.bdnodes.net&var-host=blockdaemon-audius-content-03.bdnodes.net&var-host=blockdaemon-audius-content-04.bdnodes.net&var-host=blockdaemon-audius-content-05.bdnodes.net&var-host=blockdaemon-audius-content-07.bdnodes.net&var-host=blockdaemon-audius-content-06.bdnodes.net&var-host=blockdaemon-audius-content-08.bdnodes.net&var-host=blockdaemon-audius-content-09.bdnodes.net&var-queue=update-replica-set-queue&var-percentile=0.99&viewPanel=37)

This change will fill up the queues more