### PR TITLE
configurable mem_limit for server container

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -65,6 +65,7 @@ services:
     container_name: server
     image: audius/discovery-provider:${TAG:-5eb124acf0f20021a9cda40711b7f5268aff0d07}
     restart: always
+    mem_limit: "${SERVER_MEM_LIMIT:-16000000000}"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
The 16g shorthand doesn't work, so I typed out 16,000,000,000 which is like 15g as a default.

Hoping this might prevent the dead box scenario.