### PR TITLE
Disable premium content on stage

### DIFF
--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -41,7 +41,7 @@ otelCollectorUrl=https://opentelemetry-collector.staging.audius.co/v1/traces
 mergePrimaryAndSecondaryEnabled=true
 reconfigSPIdBlacklistString=9
 maxExportClockValueRange=1000
-premiumContentEnabled=true
+premiumContentEnabled=false
 
 # required values
 creatorNodeEndpoint=


### PR DESCRIPTION
Disable premium content on stage, until we resolve why there are so may db connections caused by the premium content query.