### PR TITLE
Set expressAppConcurrency to 4

### DIFF
--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -36,6 +36,7 @@ maxRecurringRequestSyncJobConcurrency=5
 mergePrimaryAndSecondaryEnabled=false
 snapbackHighestReconfigMode=PRIMARY_AND_OR_SECONDARIES
 snapbackUsersPerJob=4000
+expressAppConcurrency=4
 
 # required values
 creatorNodeEndpoint=


### PR DESCRIPTION
> Reminder not to merge to `main` but instead to merge to `stage`. Merging to `main` should only occur via a PR from `stage` onto `main` during our deployment release schedule.

### Description

