### PR TITLE
Revert "Bump to version 0.3.69"

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -32,7 +32,7 @@ services:
 
   backend:
     container_name: server
-    image: audius/creator-node:${TAG:-e54174b75ecfc341289a8d47e726bc8f085393c8}
+    image: audius/creator-node:${TAG:-b0d04c2756e587067df2a9dd0149221abb74878c}
     depends_on:
       db:
         condition: service_healthy

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -63,7 +63,7 @@ services:
 
   backend:
     container_name: server
-    image: audius/discovery-provider:${TAG:-e54174b75ecfc341289a8d47e726bc8f085393c8}
+    image: audius/discovery-provider:${TAG:-28a19fb9aa5f99d286831cbcb84b1f25fc6da19c}
     restart: always
     mem_limit: "${SERVER_MEM_LIMIT:-16000000000}"
     depends_on:
@@ -89,7 +89,7 @@ services:
 
   indexer:
     container_name: indexer
-    image: audius/discovery-provider:${TAG:-e54174b75ecfc341289a8d47e726bc8f085393c8}
+    image: audius/discovery-provider:${TAG:-28a19fb9aa5f99d286831cbcb84b1f25fc6da19c}
     restart: always
     depends_on:
       db:
@@ -119,7 +119,7 @@ services:
       - discovery-provider-network
 
   seed:
-    image: audius/discovery-provider:${TAG:-e54174b75ecfc341289a8d47e726bc8f085393c8}
+    image: audius/discovery-provider:${TAG:-28a19fb9aa5f99d286831cbcb84b1f25fc6da19c}
     command: bash /usr/share/seed.sh ${NETWORK:-prod}
     env_file:
       - ${NETWORK:-prod}.env

--- a/identity-service/docker-compose.yml
+++ b/identity-service/docker-compose.yml
@@ -32,7 +32,7 @@ services:
 
   backend:
     container_name: server
-    image: audius/identity-service:${TAG:-e54174b75ecfc341289a8d47e726bc8f085393c8}
+    image: audius/identity-service:${TAG:-0a567453807381d859dd6e8df48c830d20b322d6}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
This reverts commit 1b8a08e993ae7597d5fafbea8e6cc656022da717.

> COMING SOON (NOT YET ACTIVE, REQUESTING FEEDBACK): Reminder not to merge to `main` but instead to merge to `stage`. Merging to `main` should only occur via a PR from `stage` onto `main` during our deployment release schedule.

### Description

