### PR TITLE
v0.3.68 Hotfix - Discovery Node Migration fix

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -63,7 +63,7 @@ services:
 
   backend:
     container_name: server
-    image: audius/discovery-provider:${TAG:-28a19fb9aa5f99d286831cbcb84b1f25fc6da19c}
+    image: audius/discovery-provider:${TAG:-fd720481af5abdb8a5fcc32cfb7fa6ca8bf82186}
     restart: always
     mem_limit: "${SERVER_MEM_LIMIT:-16000000000}"
     depends_on:
@@ -89,7 +89,7 @@ services:
 
   indexer:
     container_name: indexer
-    image: audius/discovery-provider:${TAG:-28a19fb9aa5f99d286831cbcb84b1f25fc6da19c}
+    image: audius/discovery-provider:${TAG:-fd720481af5abdb8a5fcc32cfb7fa6ca8bf82186}
     restart: always
     depends_on:
       db:
@@ -119,7 +119,7 @@ services:
       - discovery-provider-network
 
   seed:
-    image: audius/discovery-provider:${TAG:-28a19fb9aa5f99d286831cbcb84b1f25fc6da19c}
+    image: audius/discovery-provider:${TAG:-fd720481af5abdb8a5fcc32cfb7fa6ca8bf82186}
     command: bash /usr/share/seed.sh ${NETWORK:-prod}
     env_file:
       - ${NETWORK:-prod}.env


### PR DESCRIPTION
> COMING SOON (NOT YET ACTIVE, REQUESTING FEEDBACK): Reminder not to merge to `main` but instead to merge to `stage`. Merging to `main` should only occur via a PR from `stage` onto `main` during our deployment release schedule.

### Description
The inadvertent release earlier https://github.com/AudiusProject/audius-docker-compose/commit/1b8a08e993ae7597d5fafbea8e6cc656022da717 ran a discovery migration that broke discovery nodes when the code was rolled back. This applies the migration to unblock indexing without the rest of the inadvertent release.

The release branch this is cut from is here https://github.com/AudiusProject/audius-protocol/compare/release-v0.3.68