### PR TITLE
Enable disk prune for stage

### DIFF
--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -46,6 +46,7 @@ maxExportClockValueRange=1000
 premiumContentEnabled=false
 syncForceWipeEnabled=false
 reconfigModePrimaryOnly=false
+diskPruneEnabled=true
 
 # required values
 creatorNodeEndpoint=


### PR DESCRIPTION
> COMING SOON (NOT YET ACTIVE, REQUESTING FEEDBACK): Reminder not to merge to `main` but instead to merge to `stage`. Merging to `main` should only occur via a PR from `stage` onto `main` during our deployment release schedule.

### Description
Enable disk prune for stage
