### PR TITLE
Swap extra hosts from indexer to server

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -119,6 +119,8 @@ services:
       - audius_db_run_migrations=false
     networks:
       - discovery-provider-network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   indexer:
     container_name: indexer
@@ -150,8 +152,6 @@ services:
       retries: 12
     networks:
       - discovery-provider-network
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
 
   seed:
     image: audius/discovery-provider:${TAG:-e6f08c94bdd10040abb65ea91272aa854ba634f7}


### PR DESCRIPTION
### Description

`extra_hosts` was mistakenly added to the `indexer`, not the `server` which is trying to access the `exporter_linux` container.