### PR TITLE
Revert SHA back to v0.3.69 release

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
   backend:
     container_name: server
-    image: audius/creator-node:${TAG:-10b9994701ee2c0d67cf3c1275ccb57894bc4e83}
+    image: audius/creator-node:${TAG:-e6f08c94bdd10040abb65ea91272aa854ba634f7}
     restart: always
     depends_on:
       db:


### PR DESCRIPTION
> COMING SOON (NOT YET ACTIVE, REQUESTING FEEDBACK): Reminder not to merge to `main` but instead to merge to `stage`. Merging to `main` should only occur via a PR from `stage` onto `main` during our deployment release schedule.

### Description
https://github.com/AudiusProject/audius-docker-compose/commit/8e38884670d715b925061aa0120df59157475513#diff-39b7c35cc5bedaea98ec2d1ebe222809e5f49e11f51c73e2d96c823802319cbcR48 changed the SHA to an old SHA and we merged that. This reverts back to the one from the release
