### PR TITLE
Cleanup CN configs

### DIFF
--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -39,6 +39,7 @@ otelTracingEnabled=true
 otelCollectorUrl=https://opentelemetry-collector.audius.co/v1/traces
 maxAudioFileSizeBytes=1000000000
 enforceWriteQuorum=false
+backgroundDiskCleanupDeleteEnabled=true
 
 # State machine
 stateMonitoringQueueRateLimitInterval=60000

--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -1,48 +1,52 @@
 # DO NOT MODIFY these values, use `audius-cli get-config creator-node` for accurate values
 
+# Required node-specific overrides
+creatorNodeEndpoint=
+delegateOwnerWallet=
+delegatePrivateKey=
+spOwnerWallet=
+
+# Infra
 dbUrl=postgres://postgres:postgres@db:5432/audius_creator_node
 dbConnectionPoolMax=500
-
 redisHost=cache
 redisPort=6379
+enableRsyslog=false
 
+# Node.js
+timeout=3600000 # socket inactivity timeout
+headersTimeout=60000
+keepAliveTimeout=5000
+setTimeout=3600000
+
+# Chain
 dataNetworkId=99
 dataProviderUrl=https://poa-gateway.audius.co
 dataRegistryAddress=0xC611C82150b56E6e4Ec5973AcAbA8835Dd0d75A2
 entityManagerAddress=0x2F99338637F027CFB7494E46B49987457beCC6E3
 entityManagerReplicaSetEnabled=false
-disableSnapback=true
-enableRsyslog=false
 ethNetworkId=1
 ethOwnerWallet=0xe886a1858d2d368ef8f02c65bdd470396a1ab188
 ethProviderUrl=https://mainnet.infura.io/v3/a3ed533ddfca4c76ab4df7556e2745e1
 ethRegistryAddress=0xd976d3b4f4e22a238c1A736b6612D22f17b6f64C
 ethTokenAddress=0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998
-headersTimeout=60000
+
+# Application
 identityService=https://identityservice.audius.co
-keepAliveTimeout=5000
-logLevel=info
-maxAudioFileSizeBytes=1000000000
 pinAddCIDs=QmXSa6NxfA3e2hCpd8P5gNnZJs9PjZ3yGDHiRHR5B7Rq52,QmNU5Sv8se1aqfUFYFxupX1wdZfGTGnJp6vpoMbLNceGVi
-setTimeout=3600000
-stateMonitoringQueueRateLimitInterval=60000
-stateMonitoringQueueRateLimitJobsPerInterval=1
-timeout=3600000
-enforceWriteQuorum=false
+logLevel=info
 otelTracingEnabled=true
 otelCollectorUrl=https://opentelemetry-collector.audius.co/v1/traces
+maxAudioFileSizeBytes=1000000000
+enforceWriteQuorum=false
+
+# State machine
+stateMonitoringQueueRateLimitInterval=60000
+stateMonitoringQueueRateLimitJobsPerInterval=1
 maxRecurringRequestSyncJobConcurrency=16
 maxManualRequestSyncJobConcurrency=30
-snapbackHighestReconfigMode=PRIMARY_AND_OR_SECONDARIES
-snapbackUsersPerJob=4000
-contentCacheLayerEnabled=true
-reconfigModePrimaryOnly=true
+# Replica set update
 maxUpdateReplicaSetJobConcurrency=0
-backgroundDiskCleanupDeleteEnabled=true
-mergePrimaryAndSecondaryEnabled=true # to disable set to false, do not delete. controlled by default-config.json, not config.json
-
-# required values
-creatorNodeEndpoint=
-delegateOwnerWallet=
-delegatePrivateKey=
-spOwnerWallet=
+## Snapback (legacy)
+disableSnapback=true
+snapbackUsersPerJob=4000

--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -44,6 +44,8 @@ stateMonitoringQueueRateLimitJobsPerInterval=1
 maxNumberSecondsPrimaryRemainsUnhealthy=7200 # 2 hrs in seconds
 maxRecurringRequestSyncJobConcurrency=40
 maxExportClockValueRange=1000
+recordSyncResults=false
+processSyncResults=false
 ## Orphaned data recovery
 recoverOrphanedDataQueueRateLimitJobsPerInterval=1
 recoverOrphanedDataNumUsersPerBatch=10

--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -1,52 +1,58 @@
 # DO NOT MODIFY these values, use `audius-cli get-config creator-node` for accurate values
 
+# Required node-specific overrides
+creatorNodeEndpoint=
+delegateOwnerWallet=
+delegatePrivateKey=
+spOwnerWallet=
+
+# Infra
 dbUrl=postgres://postgres:postgres@db:5432/audius_creator_node
 dbConnectionPoolMax=500
-
 redisHost=cache
 redisPort=6379
+enableRsyslog=false
 
-contentCacheLayerEnabled=true
+# Node.js
+timeout=3600000 # socket inactivity timeout
+headersTimeout=60000
+keepAliveTimeout=5000
+setTimeout=3600000
+
+# Chain
 dataNetworkId=77
 dataProviderUrl=https://poa-gateway.staging.audius.co
 dataRegistryAddress=0x793373aBF96583d5eb71a15d86fFE732CD04D452
 entityManagerAddress=0x2F99338637F027CFB7494E46B49987457beCC6E3
-entityManagerReplicaSetEnabled=false
-disableSnapback=true
-enableRsyslog=false
 ethNetworkId=5
 ethOwnerWallet=
 ethProviderUrl=https://eth.staging.audius.co
 ethRegistryAddress=0xF27A9c44d7d5DDdA29bC1eeaD94718EeAC1775e3
 ethTokenAddress=0x5375BE4c52fA29b26077B0F15ee5254D779676A6
-headersTimeout=60000
+
+# Application
 identityService=https://identityservice.staging.audius.co
-keepAliveTimeout=5000
-logLevel=info
-maxAudioFileSizeBytes=1000000000
 pinAddCIDs=Qma5FGErNqHA32cyEjgp8hnwCFoqyYcBXU1ySKPA6MUJS5,QmYPy9A3zxLeBBuk1vpPNeG5aoMfa5qLNjJgh473Z9zV9b
-setTimeout=3600000
-snapbackMaxLastSuccessfulRunDelayMs=18000000 # 5hrs in ms
+otelTracingEnabled=true
+otelCollectorUrl=https://opentelemetry-collector.staging.audius.co/v1/traces
+maxAudioFileSizeBytes=1000000000
+enforceWriteQuorum=true
+
+# State machine
 stateMonitoringQueueRateLimitInterval=60000
 stateMonitoringQueueRateLimitJobsPerInterval=1
-timeout=3600000
-enforceWriteQuorum=true
 maxNumberSecondsPrimaryRemainsUnhealthy=7200 # 2 hrs in seconds
+maxRecurringRequestSyncJobConcurrency=40
+maxExportClockValueRange=1000
+## Orphaned data recovery
 recoverOrphanedDataQueueRateLimitJobsPerInterval=1
 recoverOrphanedDataNumUsersPerBatch=10
 recoverOrphanedDataDelayMsBetweenBatches=60000
-maxUpdateReplicaSetJobConcurrency=20
-maxRecurringRequestSyncJobConcurrency=40
-snapbackUsersPerJob=2000
-otelTracingEnabled=true
-otelCollectorUrl=https://opentelemetry-collector.staging.audius.co/v1/traces
+## Replica set update
+entityManagerReplicaSetEnabled=false
 reconfigSPIdBlacklistString=9
-maxExportClockValueRange=1000
-premiumContentEnabled=false
-reconfigModePrimaryOnly=false
-
-# required values
-creatorNodeEndpoint=
-delegateOwnerWallet=
-delegatePrivateKey=
-spOwnerWallet=
+maxUpdateReplicaSetJobConcurrency=20
+## Snapback (legacy)
+disableSnapback=true
+snapbackUsersPerJob=2000
+snapbackMaxLastSuccessfulRunDelayMs=18000000 # 5hrs in ms


### PR DESCRIPTION
No values were changed, just re-ordered for easier management

These configs were removed since they set to same value in `config.js`:
from prod.env:
- `snapbackHighestReconfigMode`
- `contentCacheLayerEnabled`
- `reconfigModePrimaryOnly` (unset `true`)
- `mergePrimaryAndSecondaryEnabled`
from stage.env:
- `contentCacheLayerEnabled`
- `logLevel`
- `premiumContentEnabled`
- `reconfigModePrimaryOnly`