### PR TITLE
Turn off the background disk delete

### DIFF
--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -39,7 +39,7 @@ otelTracingEnabled=true
 otelCollectorUrl=https://opentelemetry-collector.audius.co/v1/traces
 maxAudioFileSizeBytes=1000000000
 enforceWriteQuorum=false
-backgroundDiskCleanupDeleteEnabled=true
+backgroundDiskCleanupDeleteEnabled=false
 
 # State machine
 stateMonitoringQueueRateLimitInterval=60000


### PR DESCRIPTION
> COMING SOON (NOT YET ACTIVE, REQUESTING FEEDBACK): Reminder not to merge to `main` but instead to merge to `stage`. Merging to `main` should only occur via a PR from `stage` onto `main` during our deployment release schedule.

### Description
Keep the background disk checking on, but turn deleting off
