### PR TITLE
Content node config changes for v0.3.72

### DIFF
--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -47,7 +47,7 @@ stateMonitoringQueueRateLimitJobsPerInterval=1
 maxRecurringRequestSyncJobConcurrency=16
 maxManualRequestSyncJobConcurrency=30
 # Replica set update
-maxUpdateReplicaSetJobConcurrency=5
+maxUpdateReplicaSetJobConcurrency=0
 ## Snapback (legacy)
 disableSnapback=true
 snapbackUsersPerJob=4000

--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -39,7 +39,7 @@ otelTracingEnabled=false
 otelCollectorUrl=https://opentelemetry-collector.audius.co/v1/traces
 maxAudioFileSizeBytes=1000000000
 enforceWriteQuorum=false
-backgroundDiskCleanupDeleteEnabled=false
+backgroundDiskCleanupDeleteEnabled=true
 
 # State machine
 stateMonitoringQueueRateLimitInterval=60000
@@ -47,7 +47,7 @@ stateMonitoringQueueRateLimitJobsPerInterval=1
 maxRecurringRequestSyncJobConcurrency=16
 maxManualRequestSyncJobConcurrency=30
 # Replica set update
-maxUpdateReplicaSetJobConcurrency=0
+maxUpdateReplicaSetJobConcurrency=5
 ## Snapback (legacy)
 disableSnapback=true
 snapbackUsersPerJob=4000


### PR DESCRIPTION
### Description

Re-enable updateReplicaSet and backgroundDiskCleanupDeleteEnabled.

Do not merge until v0.3.72 is ready to go out and re-enabling reconfig is thoroughly tested