### PR TITLE
[CON-526] Update CN redis to v6.2.7

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -35,6 +35,22 @@ services:
         max-buffer-size: 100m
       driver: json-file
 
+  # Same as base-cache but using redis v6.2.7 instead of v5.0.5. Remove base-cache after upgrading identity and discovery to base-cache-v6
+  base-cache-v6:
+    image: redis:6.2.7
+    command: redis-server --save ""
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'PING']
+      interval: 10s
+      timeout: 5s
+    logging:
+      options:
+        max-size: 10m
+        max-file: 3
+        mode: non-blocking
+        max-buffer-size: 100m
+      driver: json-file
+
   logspout:
     image: audius/logspout:v3.2.14-1
     container_name: logspout

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     container_name: redis
     extends:
       file: ../common-services.yml
-      service: base-cache
+      service: base-cache-v6
     networks:
       - creator-node-network
   exporter_redis:


### PR DESCRIPTION
### Description
Updates version of redis image for Content Node from 5.0.5 to 6.2.7. This was tested locally in https://github.com/AudiusProject/audius-protocol/pull/4415.

TODO: Should probably wait to merge until the CN tag is auto-bumped to v0.3.72, which will contain the changes from the PR linked above.