### PR TITLE
[PLAT-538] Enable redis persistence

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -38,7 +38,7 @@ SERVICES = ("creator-node", "discovery-provider", "identity-service")
 EXTRA_VANITY = "0x22466c6578692069732061207468696e6722202d204166726900000000000000"
 EXTRA_SEAL = "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 
-# until a refactor occurs for all the calls to `compose up`
+# Until a refactor occurs for all the calls to `compose up`
 # need to reference this string in multiple places and ensure it dosent drift
 AUTO_UPGRADE_CRON_COMMENT = "audius-cli auto-upgrade"
 


### PR DESCRIPTION
### Description

Snapshot every 60 seconds so long as there has been 1 write.
This should be performant and far better than our custom persistence (especially on discovery) which persists *every* redis write for some keys to a file
https://redis.io/docs/management/persistence/

Adds `restart: always` to redis because rdb backups will let us recoup redis state if it crashes.