### PR TITLE
Version comms build with git sha.

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -107,7 +107,7 @@ services:
     container_name: exporter_linux
   
   storage:
-    image: audius/comms:a1
+    image: audius/comms:${COMMS_TAG:-b6a344ff3ab68d64df02fce2db261a7181d3b182}
     container_name: storage
     command: /comms-linux storage
     depends_on:
@@ -119,7 +119,7 @@ services:
       - override.env
 
   nats:
-    image: audius/comms:a1
+    image: audius/comms:${COMMS_TAG:-b6a344ff3ab68d64df02fce2db261a7181d3b182}
     container_name: nats
     command: /comms-linux nats
     restart: unless-stopped

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -198,7 +198,7 @@ services:
     container_name: exporter_linux
 
   comms:
-    image: audius/comms:a1
+    image: audius/comms:${COMMS_TAG:-b6a344ff3ab68d64df02fce2db261a7181d3b182}
     container_name: comms
     command: /comms-linux discovery
     depends_on:
@@ -210,7 +210,7 @@ services:
       - override.env
 
   nats:
-    image: audius/comms:a1
+    image: audius/comms:${COMMS_TAG:-b6a344ff3ab68d64df02fce2db261a7181d3b182}
     container_name: nats
     command: /comms-linux nats
     restart: unless-stopped


### PR DESCRIPTION
For now comms + nats use separate tag from other containers to allow them to restart in isolation during rollout.

Eventually comms will share TAG with other containers, and NATS will be versioned with a rarely changin version number to avoid needless NATS restarts.

