### PR TITLE
Update cleanup to do system prune instead of image prune

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -296,10 +296,9 @@ def launch(ctx, service, seed, chain, yes):
     subprocess.run(
         [
             "docker",
-            "image",
+            "system",
             "prune",
-            "--all",
-            "--force",
+            "--all"
         ],
     )
 
@@ -617,10 +616,9 @@ def upgrade(ctx, branch):
     subprocess.run(
         [
             "docker",
-            "image",
+            "system",
             "prune",
-            "--all",
-            "--force",
+            "--all"
         ],
     )
 


### PR DESCRIPTION
### Description

From SP after upgrade. This should be safe to do because the new containers running should be the only ones we care about. 

Curious for your thoughts though @cheran-senthil !

<img width="902" alt="Screenshot 2023-01-24 at 5 28 49 PM" src="https://user-images.githubusercontent.com/2731362/214679838-9f4599d5-6b09-4161-8cd7-98812c75547f.png">

