### PR TITLE
Add function to set override path

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -54,6 +54,15 @@ def get_network(ctx, service):
     )
 
 
+def get_override_path(ctx, service):
+    """Returns path to override.env for the given service."""
+    return pathlib.Path(
+        dotenv.dotenv_values(ctx.obj["manifests_path"] / service / ".env").get(
+            "OVERRIDE_PATH", ctx.obj["manifests_path"] / service / "override.env"
+        )
+    )
+
+
 def set_automatic_env(ctx):
     with crontab.CronTab(user=True) as cron:
         auto_upgrade = (
@@ -119,7 +128,7 @@ def cli(ctx):
 def check_config(ctx, service):
     """Check the config for a service"""
     env = ctx.obj["manifests_path"] / service / f"{get_network(ctx, service)}.env"
-    override_env = ctx.obj["manifests_path"] / service / "override.env"
+    override_env = get_override_path(ctx, service)
 
     env_data = dotenv.dotenv_values(env)
     override_env_data = dotenv.dotenv_values(override_env)
@@ -414,7 +423,7 @@ def set_config(ctx, service, unset, required, key, value):
     env = ctx.obj["manifests_path"] / service / f"{get_network(ctx, service)}.env"
     env_data = dotenv.dotenv_values(env)
 
-    override_env = ctx.obj["manifests_path"] / service / "override.env"
+    override_env = get_override_path(ctx, service)
     override_env_data = dotenv.dotenv_values(override_env)
 
     if required:
@@ -477,7 +486,7 @@ def get_config(ctx, service):
     else:
         env = ctx.obj["manifests_path"] / service / f"{get_network(ctx, service)}.env"
         env_data = dotenv.dotenv_values(env)
-        override_env = ctx.obj["manifests_path"] / service / "override.env"
+        override_env = get_override_path(ctx, service)
         override_env_data = dotenv.dotenv_values(override_env)
         current_env_data = {**env_data, **override_env_data}
         for key, value in current_env_data.items():
@@ -523,6 +532,31 @@ def set_tag(ctx, unset, tag):
         else:
             logging.info(f"> audius-cli set-tag service={service!r} tag={tag!r}")
             dotenv.set_key(env_file, "TAG", tag)
+
+
+@cli.command()
+@click.option("--unset", is_flag=True)
+@click.argument("service", required=False)
+@click.argument("path", type=click.Path(), required=False)
+@click.pass_context
+def set_override_path(ctx, unset, service, path):
+    """Specify alternate location for override.env"""
+    if not unset:
+        if not service:
+            service = click.prompt(click.style("Service", bold=True))
+        if not path:
+            path = click.prompt(click.style("Path", bold=True))
+
+    env_file = ctx.obj["manifests_path"] / service / ".env"
+
+    if unset:
+        logging.info(
+            f"audius-cli set-override-path unset service={service!r} path={path!r}"
+        )
+        dotenv.unset_key(env_file, "OVERRIDE_PATH")
+    else:
+        logging.info(f"audius-cli set-override-path service={service!r} path={path!r}")
+        dotenv.set_key(env_file, "OVERRIDE_PATH", path)
 
 
 @cli.command()
@@ -656,12 +690,8 @@ def launch_chain(ctx):
     Prepares the discovery chainspec and static nodes, pulling from
     relevant environment variables. Launches or resets chain acoordingly.
     """
-    network = get_network(ctx, 'discovery-provider')
-    env = (
-        ctx.obj["manifests_path"]
-        / "discovery-provider"
-        / f"{network}.env"
-    )
+    network = get_network(ctx, "discovery-provider")
+    env = ctx.obj["manifests_path"] / "discovery-provider" / f"{network}.env"
     env_data = dotenv.dotenv_values(env)
 
     # Get signers from env
@@ -681,7 +711,7 @@ def launch_chain(ctx):
         ctx.obj["manifests_path"] / "discovery-provider" / "chain" / "spec.json"
     )
     spec_data = json.load(open(spec_input))
-    
+
     prev_network_id = None
     network_id = spec_data["params"]["networkID"]
 
@@ -699,7 +729,7 @@ def launch_chain(ctx):
                 ],
             )
             clique_db_path = "/var/k8s/discovery-provider-chain/db/clique/"
-            subprocess.run(['sudo', 'rm', '-rf', clique_db_path])
+            subprocess.run(["sudo", "rm", "-rf", clique_db_path])
 
     spec_data["genesis"]["extraData"] = extra_data
     with open(spec_output, "w") as f:
@@ -722,7 +752,7 @@ def launch_chain(ctx):
             "docker",
             "compose",
             "--env-file",
-            ctx.obj["manifests_path"] / "discovery-provider" / "override.env",
+            get_override_path(ctx, "discovery-provider"),
             "--project-directory",
             ctx.obj["manifests_path"] / "discovery-provider",
             "up",
@@ -731,6 +761,7 @@ def launch_chain(ctx):
             "chain",
         ],
     )
+
 
 if __name__ == "__main__":
     cli(obj={})

--- a/audius-cli
+++ b/audius-cli
@@ -536,7 +536,7 @@ def set_tag(ctx, unset, tag):
 
 @cli.command()
 @click.option("--unset", is_flag=True)
-@click.argument("service", required=False)
+@click.argument("service", required=True)
 @click.argument("path", type=click.Path(), required=False)
 @click.pass_context
 def set_override_path(ctx, unset, service, path):

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     container_name: exporter_postgres
     env_file:
       - ${NETWORK:-prod}.env
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     command: [ "--creator-node" ]
     networks:
       - creator-node-network
@@ -38,7 +38,7 @@ services:
     container_name: exporter_redis
     env_file:
       - ${NETWORK:-prod}.env
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     command: [ "--creator-node" ]
     networks:
       - creator-node-network
@@ -60,7 +60,7 @@ services:
       - "4000:4000"
     env_file:
       - ${NETWORK:-prod}.env
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     environment:
       - audiusContentInfraSetup=audius-docker-compose
     networks:
@@ -96,7 +96,7 @@ services:
       file: ../common-services.yml
       service: logspout
     env_file:
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     networks:
       - creator-node-network
 
@@ -105,7 +105,7 @@ services:
       file: ../common-services.yml
       service: exporter_linux
     container_name: exporter_linux
-  
+
   storage:
     image: audius/comms:${COMMS_TAG:-b6a344ff3ab68d64df02fce2db261a7181d3b182}
     container_name: storage
@@ -116,7 +116,7 @@ services:
     networks:
       - creator-node-network
     env_file:
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     logging:
       options:
         max-size: 10m
@@ -136,7 +136,7 @@ services:
       - "6222:6222"
       - "4222:4222"
     env_file:
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     environment:
       - NATS_STORE_DIR=/nats
     volumes:

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     container_name: exporter_postgres
     env_file:
       - ${NETWORK:-prod}.env
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     networks:
       - discovery-provider-network
   exporter_postgres_read_replica:
@@ -29,7 +29,7 @@ services:
     container_name: exporter_postgres_read_replica
     env_file:
       - ${NETWORK:-prod}.env
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     command: [ "--read-replica" ]
     networks:
       - discovery-provider-network
@@ -49,7 +49,7 @@ services:
     container_name: exporter_redis
     env_file:
       - ${NETWORK:-prod}.env
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     networks:
       - discovery-provider-network
 
@@ -94,7 +94,7 @@ services:
       ]
     env_file:
       - ${NETWORK:-prod}.env
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     networks:
       - discovery-provider-network
 
@@ -116,7 +116,7 @@ services:
       - "5000:5000"
     env_file:
       - ${NETWORK:-prod}.env
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     environment:
       - audius_discprov_infra_setup=audius-docker-compose
       - audius_no_workers=true
@@ -141,7 +141,7 @@ services:
       autoheal: "true"
     env_file:
       - ${NETWORK:-prod}.env
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     environment:
       - audius_discprov_infra_setup=audius-docker-compose
       - audius_no_server=true
@@ -162,7 +162,7 @@ services:
     command: bash /usr/share/seed.sh ${NETWORK:-prod}
     env_file:
       - ${NETWORK:-prod}.env
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     volumes:
       - ./seed.sh:/usr/share/seed.sh
     depends_on:
@@ -187,7 +187,7 @@ services:
       file: ../common-services.yml
       service: logspout
     env_file:
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     networks:
       - discovery-provider-network
 
@@ -207,7 +207,7 @@ services:
     networks:
       - discovery-provider-network
     env_file:
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     logging:
       options:
         max-size: 10m
@@ -227,7 +227,7 @@ services:
       - "6222:6222"
       - "4222:4222"
     env_file:
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     environment:
       - NATS_STORE_DIR=/nats
     volumes:
@@ -246,7 +246,7 @@ services:
     container_name: chain
     env_file:
       - ${NETWORK:-prod}.env
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     environment:
       - NETHERMIND_KEYSTORECONFIG_TESTNODEKEY=${audius_delegate_private_key}
     volumes:

--- a/identity-service/docker-compose.yml
+++ b/identity-service/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     container_name: exporter_postgres
     env_file:
       - ${NETWORK:-prod}.env
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     command: [ "--identity-service" ]
     ports:
       - "127.0.0.1:9187:9187"
@@ -40,7 +40,7 @@ services:
     container_name: exporter_redis
     env_file:
       - ${NETWORK:-prod}.env
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     command: [ "--identity-service" ]
     ports:
       - "127.0.0.1:9121:9121"
@@ -61,7 +61,7 @@ services:
       - "7000:7000"
     env_file:
       - ${NETWORK}.env
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     networks:
       - identity-service-network
 
@@ -79,7 +79,7 @@ services:
       file: ../common-services.yml
       service: logspout
     env_file:
-      - override.env
+      - ${OVERRIDE_PATH:-override.env}
     networks:
       - identity-service-network
 


### PR DESCRIPTION
### Description

Adds a function to `audius-cli` and makes associated changes to `set-override-path`

This let's us set an arbitrary path for `override.env`

Tested on staging