### PR TITLE
1 second block time

### DIFF
--- a/discovery-provider/chain/prod_spec_template.json
+++ b/discovery-provider/chain/prod_spec_template.json
@@ -4,7 +4,7 @@
   "engine": {
     "clique": {
       "params": {
-        "period": 5,
+        "period": 1,
         "epoch": 30000
       }
     }
@@ -34,7 +34,7 @@
     "maxCodeSizeTransition": "0x0",
     "maximumExtraDataSize": "0x320",
     "minGasLimit": "0x1388",
-    "networkID": "0x102020",
+    "networkID": "0x102021",
     "validateReceipts": false,
     "validateReceiptsTransition": "0xffffffffffffffff",
     "wasmActivationTransition": "0xffffffffffffffff"

--- a/discovery-provider/chain/stage_spec_template.json
+++ b/discovery-provider/chain/stage_spec_template.json
@@ -4,7 +4,7 @@
     "engine": {
       "clique": {
         "params": {
-          "period": 5,
+          "period": 1,
           "epoch": 30000
         }
       }
@@ -34,7 +34,7 @@
       "maxCodeSizeTransition": "0x0",
       "maximumExtraDataSize": "0x320",
       "minGasLimit": "0x1388",
-      "networkID": "0x102020",
+      "networkID": "0x102021",
       "validateReceipts": false,
       "validateReceiptsTransition": "0xffffffffffffffff",
       "wasmActivationTransition": "0xffffffffffffffff"

--- a/discovery-provider/prod.env
+++ b/discovery-provider/prod.env
@@ -49,4 +49,4 @@ audius_delegate_private_key=
 audius_discprov_url=
 
 # chain 
-audius_discprov_max_signers=1
+audius_discprov_max_signers=0


### PR DESCRIPTION
### Description

Make block time 1 second. Already running on stage. Prod chain is unhealthy / not used right now so this should be safe to merge.

Increment network ID to avoid cross network peering and changing network ID will trigger resetting the chain.

Prod chain stopped producing blocks. I believe because of the proposing. Disabling that for now by setting `audius_discprov_max_signers=0`. 