### PR TITLE
Prepend https:// to creatorNodeEndpoint

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
   backend:
     container_name: server
-    image: audius/creator-node:${TAG:-8077ddef49955f66fb8a82dfedb3bfc97bd2b595}
+    image: audius/creator-node:${TAG:-b1de448ed1bd2e7c64c33cac019ba8e265c17a21}
     restart: always
     depends_on:
       db:


### PR DESCRIPTION
### Description
Updates creator-node sha to [this cherry-picked commit](https://github.com/AudiusProject/audius-protocol/commit/9030672df38f1410677465afc4060efa0792534a) that prepends `https://` to the `creatorNodeEndpoint` env var when it's missing.

This will be ready to merge when the above linked commit is auto-deployed to staging and we confirm that staging nodes' `/config_check` endpoints display valid `creatorNodeEndpoint` and `spID`.