### PR TITLE
Add AUDIUS_IS_STAGING env var

### DIFF
--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -31,6 +31,7 @@ ethRegistryAddress=0xF27A9c44d7d5DDdA29bC1eeaD94718EeAC1775e3
 ethTokenAddress=0x5375BE4c52fA29b26077B0F15ee5254D779676A6
 
 # Application
+AUDIUS_IS_STAGING=true
 identityService=https://identityservice.staging.audius.co
 pinAddCIDs=Qma5FGErNqHA32cyEjgp8hnwCFoqyYcBXU1ySKPA6MUJS5,QmYPy9A3zxLeBBuk1vpPNeG5aoMfa5qLNjJgh473Z9zV9b
 otelTracingEnabled=true

--- a/discovery-provider/stage.env
+++ b/discovery-provider/stage.env
@@ -12,6 +12,7 @@ audius_cors_allow_all=true
 audius_openresty_enable=true
 audius_discprov_blacklist_block_processing_window=1200
 audius_discprov_block_processing_window=100
+AUDIUS_IS_STAGING=true
 audius_discprov_env=stage
 audius_discprov_get_users_cnode_ttl_sec=300
 audius_discprov_identity_service_url=https://identityservice.staging.audius.co


### PR DESCRIPTION
### Description
Sets `AUDIUS_IS_STAGING` to true for creator node and discovery provider. This is the get rid of the "hack" [here](https://github.com/AudiusProject/audius-protocol/blob/main/comms/discovery/config/config.go#L67-L71) so I can consolidate branching logic into a shared config. No prod changes will be needed since the code will default to false if it's not explicitly set.

Note: it would be better to not add this extra env var to discovery since discovery already has `audius_discprov_env=stage`, but it doesn't make sense for storage to set an env var with `discprov` in its name. Loading envconfig is more straightforward if the same `AUDIUS_IS_STAGING` env var is present in both comms and storage.