### PR TITLE
Add admin module

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -604,9 +604,9 @@ def pull(ctx, branch):
 @click.pass_context
 def upgrade(ctx, branch):
     """Pulls from latest source and re-launches all running services"""
-    set_automatic_env(ctx)
-
     ctx.forward(pull)
+
+    set_automatic_env(ctx)
 
     for service in SERVICES:
         proc = subprocess.run(

--- a/audius-cli
+++ b/audius-cli
@@ -605,7 +605,6 @@ def pull(ctx, branch):
 def upgrade(ctx, branch):
     """Pulls from latest source and re-launches all running services"""
     ctx.forward(pull)
-
     set_automatic_env(ctx)
 
     for service in SERVICES:

--- a/discovery-provider/chain/config.cfg
+++ b/discovery-provider/chain/config.cfg
@@ -21,6 +21,7 @@
     "JsonRpc": {
         "Enabled": true,
         "EnabledModules": [
+            "Admin",
             "Eth",
             "Subscribe",
             "Trace",


### PR DESCRIPTION
### Description
Add admin module for chain troubleshooting https://docs.nethermind.io/nethermind/ethereum-client/json-rpc/admin

Also I think we should pull then set env vars, this way the compose commit that's exposed in health_check is more accurate. I think the first time it auto-upgrades to a commit it'll actually still show the previous commit. I think it doesn't get corrected until the next auto-upgrade. 