### PR TITLE
Remove NATS_STORE_DIR env var

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -142,7 +142,6 @@ services:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}
     environment:
-      - NATS_STORE_DIR=/nats
       - LOGSPOUT=ignore
     volumes:
       - /var/k8s/nats:/nats

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -233,7 +233,6 @@ services:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}
     environment:
-      - NATS_STORE_DIR=/nats
       - LOGSPOUT=ignore
     volumes:
       - /var/k8s/nats:/nats


### PR DESCRIPTION
### Description
The `NATS_STORE_DIR` env var is no longer needed since we now default it to the same value [here](https://github.com/AudiusProject/audius-protocol/blob/main/comms/natsd/config/config.go#L12). This is live on staging, but I'll wait to merge this until that config change reaches prod.