### PR TITLE
Revert nethermind version back to 14.3

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -245,7 +245,7 @@ services:
       driver: json-file
 
   chain:
-    image: nethermind/nethermind:1.17.0
+    image: nethermind/nethermind:1.14.3
     command: --config config
     container_name: chain
     env_file:

--- a/discovery-provider/stage.env
+++ b/discovery-provider/stage.env
@@ -7,6 +7,7 @@ audius_db_url_read_replica=postgresql://postgres:postgres@db:5432/audius_discove
 
 audius_contracts_registry=0x793373aBF96583d5eb71a15d86fFE732CD04D452
 audius_contracts_entity_manager_address=0x1Cd8a543596D499B9b6E7a6eC15ECd2B7857Fd64
+audius_contracts_nethermind_entity_manager_address=0x1Cd8a543596D499B9b6E7a6eC15ECd2B7857Fd64
 audius_contracts_verified_address=0xbbbb93A6B3A1D6fDd27909729b95CCB0cc9002C0
 audius_cors_allow_all=true
 audius_openresty_enable=true
@@ -38,6 +39,7 @@ audius_solana_user_bank_program_address=2sjQNmUfkV6yKKi4dPR8gWRgtyma5aiymE3aXL2R
 audius_solana_waudio_mint=BELGiMZQ34SDE6x2FUaML2UHDAgBLS64xvhXjX5tBBZo
 audius_web3_eth_provider_url=https://eth.staging.audius.co
 audius_web3_host=poa-gateway.staging.audius.co
+audius_web3_nethermind_rpc=https://poa-gateway.staging.audius.co
 audius_web3_port=443
 audius_discprov_backfill_social_rewards_blocknumber=27214200
 


### PR DESCRIPTION
### Description

Revert version because 17.1 is unable to clique propose for some reason...

```
{"jsonrpc":"2.0","error":{"code":-32603,"message":"Unable to cast vote: System.InvalidOperationException: Not a signer node - cannot vote\n   at Nethermind.Consensus.Clique.CliqueRpcModule.CastVote(Address signer, Boolean vote) in /src/Nethermind/Nethermind.Consensus.Clique/CliqueRpcModule.cs:line 44\n   at Nethermind.Consensus.Clique.CliqueRpcModule.clique_propose(Address signer, Boolean vote) in /src/Nethermind/Nethermind.Consensus.Clique/CliqueRpcModule.cs:line 167","data":false},"id":1
```

also adding some configs for our stage nodes just in case. they're already set in the override though.