### PR TITLE
Creator separate nginx

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -43,6 +43,16 @@ services:
     networks:
       - creator-node-network
 
+  openresty:
+    container_name: openresty
+    image: openresty/openresty
+    networks:
+      - creator-node-network
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./nginx:/etc/nginx/conf.d
+
   backend:
     container_name: server
     image: audius/creator-node:${TAG:-b3b90ba7e80fad3b876c63678830f52b61f93d3c}
@@ -56,8 +66,6 @@ services:
       - /var/k8s/creator-node-backend:/file_storage # Use k8s location for backward compatibility
     labels:
       autoheal: "true"
-    ports:
-      - "4000:4000"
     env_file:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}

--- a/creator-node/nginx/creator_nginx.conf
+++ b/creator-node/nginx/creator_nginx.conf
@@ -1,0 +1,149 @@
+# nginx Configuration file
+#
+# Notes:
+#   - any value below prefixed with $arg indicates a request query param, e.g. $arg_bypasscache will match query param `bypasscache=<value>`
+# Nginx location regex examples: https://linuxhint.com/nginx-location-regex-examples/
+
+worker_processes 8;
+
+events {
+    worker_connections 4096;
+}
+
+http {
+    log_format format_with_cache_status '$remote_addr - $remote_user [$time_local] '
+                       '"$request" $status x-cache-status=$upstream_cache_status $bytes_sent '
+                       '"$http_referer" "$http_user_agent" "$gzip_ratio"';
+    access_log /usr/local/openresty/logs/access.log format_with_cache_status;
+
+    # A value of 0 disables client upload size check on the nginx proxy layer, and shifts the responsibility
+    # back to the app
+    client_max_body_size 0;
+    lua_package_path "/usr/local/openresty/conf/?.lua;;";
+
+    # Inactive = how long an item can remain in the cache without being accessed
+    # If inactive period passes, content WILL BE DELETED from the cache by the cache
+    # manager, regardless whether or not it has expired.
+    # https://www.nginx.com/blog/nginx-caching-guide#How-to-Set-Up-and-Configure-Basic-Caching
+    proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cache:1000m
+					max_size=4g inactive=12h use_temp_path=off;
+    proxy_read_timeout 3600; # 1 hour in seconds
+
+    server {
+        listen 4000;
+
+        # Match the paths /ipfs/<cid: string> and /content/<cid: string>.
+        # If present in cache, serve. Else, hit upstream server + update cache + serve.
+        # http://nginx.org/en/docs/http/ngx_http_core_module.html#location
+        location ~ (/ipfs/|/content/) {
+            proxy_cache cache;
+            proxy_pass http://127.0.0.1:3000;
+
+            # Set client IP as `X-Forwarded-For` response header
+            proxy_set_header X-Forwarded-For $remote_addr;
+
+            # Cache responses with certain status codes for some duration before considered stale.
+            # Stale implies content will be fetched from the upstream server. Stale content WILL NOT
+            # BE REMOVED from the cache.
+            proxy_cache_valid 200 12h;
+            proxy_cache_valid 401 403 0s;
+            proxy_cache_valid any 1s;
+
+            # When enabled, only one request at a time will be allowed to populate a new cache element
+            # Other requests of the same cache element will either wait for a response to appear in the cache
+            # or the cache lock for this element to be released
+            proxy_cache_lock on;
+            # If the last request passed to the proxied server for populating a new cache element has not
+            # completed for the specified time, one more request may be passed to the proxied server
+            proxy_cache_lock_age 1s;
+            # When 2s passes, the request will be passed to the proxied server, however, the response will not be cached
+            proxy_cache_lock_timeout 2s;
+
+            # Bypass cache with bypasscache=true query string and save new response to proxy cache
+            proxy_cache_bypass $arg_bypasscache;
+
+            # Add header to indicate the status of the cache with this request
+            add_header X-Cache-Status $upstream_cache_status always;
+        }
+
+        # Regex matches any path that begins with /health_check (case-sensitive)
+        # Note this will also include other health check routes /health_check/verbose, /health_check/sync, /health_check/duration, /health_check/duration/heartbeat, /health_check/fileupload
+        location ~ (/health_check) {
+            proxy_cache cache;
+
+            proxy_pass http://127.0.0.1:3000;
+
+            # Set client IP as `X-Forwarded-For` response header
+            proxy_set_header X-Forwarded-For $remote_addr;
+
+            # proxy_cache_use_stale + proxy_cache_background_update -> deliver stale content when client requests
+            # an item that is expired or in the process of being updated from origin server
+            proxy_cache_use_stale timeout updating http_500 http_502 http_503 http_504;
+            proxy_cache_background_update on;
+
+            # Cache all responses for 1s
+            proxy_cache_valid any 1s;
+
+            # Bypass cache with bypasscache=true query string and save new response to proxy cache
+            proxy_cache_bypass $arg_bypasscache;
+
+            # Add response header to indicate the status of the cache with this request
+            add_header X-Cache-Status $upstream_cache_status always;
+        }
+
+        # $upstream references the audius-docker-compose network'd containers
+        location /prometheus/postgres {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream exporter_postgres:9187;
+            proxy_pass http://$upstream/metrics;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /prometheus/redis {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream exporter_redis:9121;
+            proxy_pass http://$upstream/metrics;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /nats {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream nats:8924;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location /storage {
+            client_max_body_size 500M;
+            resolver 127.0.0.11 valid=30s;
+            set $upstream storage:8926;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            # for websockets:
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+        location /mediorum {
+            client_max_body_size 500M;
+            resolver 127.0.0.11 valid=30s;
+            set $upstream mediorum:1991;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            # for websockets:
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+
+        # Pass all other requests to upstream server
+        location / {
+            proxy_pass http://127.0.0.1:3000;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+    }
+}

--- a/creator-node/nginx/creator_nginx.conf
+++ b/creator-node/nginx/creator_nginx.conf
@@ -4,17 +4,17 @@
 #   - any value below prefixed with $arg indicates a request query param, e.g. $arg_bypasscache will match query param `bypasscache=<value>`
 # Nginx location regex examples: https://linuxhint.com/nginx-location-regex-examples/
 
-worker_processes 8;
+# worker_processes 8;
 
-events {
-    worker_connections 4096;
-}
+# events {
+#     worker_connections 4096;
+# }
 
-http {
-    log_format format_with_cache_status '$remote_addr - $remote_user [$time_local] '
-                       '"$request" $status x-cache-status=$upstream_cache_status $bytes_sent '
-                       '"$http_referer" "$http_user_agent" "$gzip_ratio"';
-    access_log /usr/local/openresty/logs/access.log format_with_cache_status;
+# http {
+    # log_format format_with_cache_status '$remote_addr - $remote_user [$time_local] '
+    #                    '"$request" $status x-cache-status=$upstream_cache_status $bytes_sent '
+    #                    '"$http_referer" "$http_user_agent" "$gzip_ratio"';
+    # access_log /usr/local/openresty/logs/access.log format_with_cache_status;
 
     # A value of 0 disables client upload size check on the nginx proxy layer, and shifts the responsibility
     # back to the app
@@ -36,8 +36,11 @@ http {
         # If present in cache, serve. Else, hit upstream server + update cache + serve.
         # http://nginx.org/en/docs/http/ngx_http_core_module.html#location
         location ~ (/ipfs/|/content/) {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream backend:4000;
+
             proxy_cache cache;
-            proxy_pass http://127.0.0.1:3000;
+            proxy_pass http://$upstream;
 
             # Set client IP as `X-Forwarded-For` response header
             proxy_set_header X-Forwarded-For $remote_addr;
@@ -69,9 +72,11 @@ http {
         # Regex matches any path that begins with /health_check (case-sensitive)
         # Note this will also include other health check routes /health_check/verbose, /health_check/sync, /health_check/duration, /health_check/duration/heartbeat, /health_check/fileupload
         location ~ (/health_check) {
-            proxy_cache cache;
+            resolver 127.0.0.11 valid=30s;
+            set $upstream backend:4000;
 
-            proxy_pass http://127.0.0.1:3000;
+            proxy_cache cache;
+            proxy_pass http://$upstream;
 
             # Set client IP as `X-Forwarded-For` response header
             proxy_set_header X-Forwarded-For $remote_addr;
@@ -142,8 +147,10 @@ http {
 
         # Pass all other requests to upstream server
         location / {
-            proxy_pass http://127.0.0.1:3000;
+            resolver 127.0.0.11 valid=30s;
+            set $upstream backend:4000;
+            proxy_pass http://$upstream;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
     }
-}
+# }

--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -49,3 +49,7 @@ maxManualRequestSyncJobConcurrency=30
 ## Snapback (legacy)
 disableSnapback=true
 snapbackUsersPerJob=2000
+
+# false => don't start nginx inside of creator node container
+# set to false if openresty container is running in docker-compose
+contentCacheLayerEnabled=false

--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -62,3 +62,8 @@ snapbackUsersPerJob=500
 snapbackMaxLastSuccessfulRunDelayMs=18000000 # 5hrs in ms
 maxNumberSecondsPrimaryRemainsUnhealthy=60
 maxNumberSecondsSecondaryRemainsUnhealthy=30
+
+
+# false => don't start nginx inside of creator node container
+# set to false if openresty container is running in docker-compose
+contentCacheLayerEnabled=false


### PR DESCRIPTION
### Description

Moves creator node nginx to a separate container, so that we can change routes without (slow) creator node restart.

This mounts config into `conf.d` which gets included by the [default config](https://github.com/openresty/docker-openresty/blob/master/nginx.conf).

As such I commented out top level directives, like logging etc.  You can see the diff in nginx config between the first and second commit.  In the interest of keeping diff clear I left everything in place and commented stuff out... if we are good with `include` method we can remove the noise.  We can also replace top level nginx.conf instead as described [here](https://github.com/openresty/docker-openresty/tree/master#nginx-config-files)... we'll just need to update logging locations to directories that exist.

I don't think any of this top level config is essential, except for maybe the logging config.  If the logging file output is important / consumed elsewhere, this will require more thought.

tested on stage-creator-10.