### PR TITLE
remove nats, update dms

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -345,6 +345,7 @@ def launch(ctx, service, seed, chain, yes):
             ctx.obj["manifests_path"] / service,
             "up",
             "-d",
+            "--remove-orphans",
         ],
         check=True,
     )
@@ -702,6 +703,7 @@ def upgrade(ctx, branch):
                     ctx.obj["manifests_path"] / service,
                     "up",
                     "-d",
+                    "--remove-orphans",
                 ],
             )
 

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -106,53 +106,6 @@ services:
       service: exporter_linux
     container_name: exporter_linux
 
-  storage:
-    image: audius/comms:${COMMS_TAG:-6b80fc720ab75c8fa8f587207a7b5b798d38326d}
-    container_name: storage
-    command: storage
-    depends_on:
-      - nats
-    restart: unless-stopped
-    networks:
-      - creator-node-network
-    env_file:
-      - ${NETWORK:-prod}.env
-      - ${OVERRIDE_PATH:-override.env}
-    environment:
-      - LOGSPOUT=ignore
-    logging:
-      options:
-        max-size: 10m
-        max-file: 3
-        mode: non-blocking
-        max-buffer-size: 100m
-      driver: json-file
-
-  nats:
-    image: audius/comms:${COMMS_TAG:-6b80fc720ab75c8fa8f587207a7b5b798d38326d}
-    container_name: nats
-    command: nats
-    restart: unless-stopped
-    networks:
-      - creator-node-network
-    ports:
-      - "6222:6222"
-      - "4222:4222"
-    env_file:
-      - ${NETWORK:-prod}.env
-      - ${OVERRIDE_PATH:-override.env}
-    environment:
-      - LOGSPOUT=ignore
-    volumes:
-      - /var/k8s/nats:/nats
-    logging:
-      options:
-        max-size: 10m
-        max-file: 3
-        mode: non-blocking
-        max-buffer-size: 100m
-      driver: json-file
-
   mediorum:
     image: audius/mediorum:latest
     container_name: mediorum

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -198,11 +198,9 @@ services:
     container_name: exporter_linux
 
   comms:
-    image: audius/comms:${COMMS_TAG:-6b80fc720ab75c8fa8f587207a7b5b798d38326d}
+    image: audius/comms:${COMMS_TAG:-8ec674071f2bdc8b024a21a96ffa143ffcf44e15}
     container_name: comms
     command: discovery
-    depends_on:
-      - nats
     restart: unless-stopped
     networks:
       - discovery-provider-network
@@ -211,31 +209,6 @@ services:
       - ${OVERRIDE_PATH:-override.env}
     environment:
       - LOGSPOUT=ignore
-    logging:
-      options:
-        max-size: 10m
-        max-file: 3
-        mode: non-blocking
-        max-buffer-size: 100m
-      driver: json-file
-
-  nats:
-    image: audius/comms:${COMMS_TAG:-6b80fc720ab75c8fa8f587207a7b5b798d38326d}
-    container_name: nats
-    command: nats
-    restart: unless-stopped
-    networks:
-      - discovery-provider-network
-    ports:
-      - "6222:6222"
-      - "4222:4222"
-    env_file:
-      - ${NETWORK:-prod}.env
-      - ${OVERRIDE_PATH:-override.env}
-    environment:
-      - LOGSPOUT=ignore
-    volumes:
-      - /var/k8s/nats:/nats
     logging:
       options:
         max-size: 10m


### PR DESCRIPTION
### Description

adds `--remove-orphans` to docker commands to ensure `nats` and `storage` go away.