### PR TITLE
PLAT-858: register plugins on auto upgrade

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -863,7 +863,7 @@ def launch_notifications(ctx):
 
 @cli.command()
 @click.pass_context
-@click.argument("name", required=False)
+@click.argument("name", required=True)
 def register_plugin(ctx, name):
     plugins = dotenv.get_key(REGISTERED_PLUGINS)
     if plugins is not None:
@@ -878,7 +878,7 @@ def register_plugin(ctx, name):
 
 @cli.command()
 @click.pass_context
-@click.argument("name", required=False)
+@click.argument("name", required=True)
 def deregister_plugin(ctx, name):
     plugins = dotenv.get_key(REGISTERED_PLUGINS)
     if plugins is not None:

--- a/audius-cli
+++ b/audius-cli
@@ -895,6 +895,14 @@ def plugin_deregister(ctx, name):
     dotenv.set_key(override_env, REGISTERED_PLUGINS, plugins)
     return
 
+@cli.command()
+@click.pass_context
+def plugins(ctx):
+    override_env = get_override_path(ctx, "discovery-provider")
+    plugins = dotenv.get_key(override_env, REGISTERED_PLUGINS)
+    print(f"registered plugins: {plugins}")
+    return
+
 
 if __name__ == "__main__":
     cli(obj={})

--- a/audius-cli
+++ b/audius-cli
@@ -911,7 +911,7 @@ def launch_notifications(ctx):
 @cli.command()
 @click.pass_context
 @click.argument("name", required=True)
-def plugin_register(ctx, name):
+def register_plugin(ctx, name):
     print(f"registering plugin {name}")
     override_env = get_override_path(ctx, "discovery-provider")
     plugins = dotenv.get_key(override_env, REGISTERED_PLUGINS)
@@ -928,19 +928,19 @@ def plugin_register(ctx, name):
 @cli.command()
 @click.pass_context
 @click.argument("name", required=True)
-def plugin_deregister(ctx, name):
+def deregister_plugin(ctx, name):
     print(f"deregistering plugin {name}")
     override_env = get_override_path(ctx, "discovery-provider")
     plugins = dotenv.get_key(override_env, REGISTERED_PLUGINS)
     if plugins is not None:
         plugins = plugins.split(",")
     else:
-        return []
+        return
     if name in plugins:
         plugins.remove(name)
         # last plugin removed
         if not plugins:
-            return []
+            return
     plugins = ",".join(plugins)
     dotenv.set_key(override_env, REGISTERED_PLUGINS, plugins)
     return
@@ -948,7 +948,7 @@ def plugin_deregister(ctx, name):
 
 @cli.command()
 @click.pass_context
-def plugins(ctx):
+def print_plugins(ctx):
     override_env = get_override_path(ctx, "discovery-provider")
     plugins = dotenv.get_key(override_env, REGISTERED_PLUGINS)
     print(f"registered plugins: {plugins}")

--- a/audius-cli
+++ b/audius-cli
@@ -762,7 +762,6 @@ def upgrade(ctx, branch):
     )
 
 
-
 @cli.command()
 @click.option("--remove", is_flag=True)
 # random so nodes in the network stagger upgrades
@@ -938,6 +937,9 @@ def plugin_deregister(ctx, name):
         return []
     if name in plugins:
         plugins.remove(name)
+        # last plugin removed
+        if not plugins:
+            return []
     plugins = ",".join(plugins)
     dotenv.set_key(override_env, REGISTERED_PLUGINS, plugins)
     return

--- a/audius-cli
+++ b/audius-cli
@@ -865,6 +865,7 @@ def launch_notifications(ctx):
 @click.pass_context
 @click.argument("name", required=True)
 def register_plugin(ctx, name):
+    print(f"registering plugin {name}")
     plugins = dotenv.get_key(REGISTERED_PLUGINS)
     if plugins is not None:
         plugins = plugins.split(",")
@@ -880,6 +881,7 @@ def register_plugin(ctx, name):
 @click.pass_context
 @click.argument("name", required=True)
 def deregister_plugin(ctx, name):
+    print(f"deregistering plugin {name}")
     plugins = dotenv.get_key(REGISTERED_PLUGINS)
     if plugins is not None:
         plugins = plugins.split(",")

--- a/audius-cli
+++ b/audius-cli
@@ -40,6 +40,8 @@ SERVICES = (
     "identity-service",
 )
 
+REGISTERED_PLUGINS = "REGISTERED_PLUGINS"
+
 # Used for updating chainspec
 EXTRA_VANITY = "0x22466c6578692069732061207468696e6722202d204166726900000000000000"
 EXTRA_SEAL = "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
@@ -857,6 +859,37 @@ def launch_notifications(ctx):
             "notifications",
         ],
     )
+
+
+@cli.command()
+@click.pass_context
+@click.argument("name", required=False)
+def register_plugin(ctx, name):
+    plugins = dotenv.get_key(REGISTERED_PLUGINS)
+    if plugins is not None:
+        plugins = plugins.split(",")
+    else:
+        plugins = []
+    plugins.append(name)
+    plugins = ",".join(plugins)
+    dotenv.set_key(REGISTERED_PLUGINS, plugins)
+    return
+
+
+@cli.command()
+@click.pass_context
+@click.argument("name", required=False)
+def deregister_plugin(ctx, name):
+    plugins = dotenv.get_key(REGISTERED_PLUGINS)
+    if plugins is not None:
+        plugins = plugins.split(",")
+    else:
+        return []
+    if name in plugins:
+        plugins.remove(name)
+    plugins = ",".join(plugins)
+    dotenv.set_key(REGISTERED_PLUGINS, plugins)
+    return
 
 
 if __name__ == "__main__":

--- a/audius-cli
+++ b/audius-cli
@@ -80,37 +80,38 @@ def launch_plugins(ctx):
     if plugins is not None:
         plugins = plugins.split(",")
         for plugin in plugins:
-            subprocess.run(
-                [
-                    "docker",
-                    "compose",
-                    "--project-directory",
-                    ctx.obj["manifests_path"] / "discovery-provider",
-                    "-f",
-                    ctx.obj["manifests_path"]
-                    / "discovery-provider"
-                    / f"docker-compose.{plugin}.yml",
-                    "pull",
-                ],
-                check=True,
-            )
+            if not plugin:
+                subprocess.run(
+                    [
+                        "docker",
+                        "compose",
+                        "--project-directory",
+                        ctx.obj["manifests_path"] / "discovery-provider",
+                        "-f",
+                        ctx.obj["manifests_path"]
+                        / "discovery-provider"
+                        / f"docker-compose.{plugin}.yml",
+                        "pull",
+                    ],
+                    check=True,
+                )
 
-            subprocess.run(
-                [
-                    "docker",
-                    "compose",
-                    "--project-directory",
-                    ctx.obj["manifests_path"] / "discovery-provider",
-                    "-f",
-                    ctx.obj["manifests_path"]
-                    / "discovery-provider"
-                    / f"docker-compose.{plugin}.yml",
-                    "up",
-                    "--no-recreate",
-                    "-d",
-                    f"{plugin}",
-                ],
-            )
+                subprocess.run(
+                    [
+                        "docker",
+                        "compose",
+                        "--project-directory",
+                        ctx.obj["manifests_path"] / "discovery-provider",
+                        "-f",
+                        ctx.obj["manifests_path"]
+                        / "discovery-provider"
+                        / f"docker-compose.{plugin}.yml",
+                        "up",
+                        "--no-recreate",
+                        "-d",
+                        f"{plugin}",
+                    ],
+                )
     return
 
 

--- a/audius-cli
+++ b/audius-cli
@@ -864,7 +864,7 @@ def launch_notifications(ctx):
 @cli.command()
 @click.pass_context
 @click.argument("name", required=True)
-def register_plugin(ctx, name):
+def plugin_register(ctx, name):
     print(f"registering plugin {name}")
     plugins = dotenv.get_key(REGISTERED_PLUGINS)
     if plugins is not None:
@@ -880,7 +880,7 @@ def register_plugin(ctx, name):
 @cli.command()
 @click.pass_context
 @click.argument("name", required=True)
-def deregister_plugin(ctx, name):
+def plugin_deregister(ctx, name):
     print(f"deregistering plugin {name}")
     plugins = dotenv.get_key(REGISTERED_PLUGINS)
     if plugins is not None:

--- a/audius-cli
+++ b/audius-cli
@@ -72,6 +72,48 @@ def get_override_path(ctx, service):
     )
 
 
+def launch_plugins(ctx):
+    # install registered plugins after upgrade
+    # assumes plugins are only for discprov
+    override_env = get_override_path(ctx, "discovery-provider")
+    plugins = dotenv.get_key(override_env, REGISTERED_PLUGINS)
+    if plugins is not None:
+        plugins = plugins.split(",")
+        for plugin in plugins:
+            subprocess.run(
+                [
+                    "docker",
+                    "compose",
+                    "--project-directory",
+                    ctx.obj["manifests_path"] / "discovery-provider",
+                    "-f",
+                    ctx.obj["manifests_path"]
+                    / "discovery-provider"
+                    / f"docker-compose.{plugin}.yml",
+                    "pull",
+                ],
+                check=True,
+            )
+
+            subprocess.run(
+                [
+                    "docker",
+                    "compose",
+                    "--project-directory",
+                    ctx.obj["manifests_path"] / "discovery-provider",
+                    "-f",
+                    ctx.obj["manifests_path"]
+                    / "discovery-provider"
+                    / f"docker-compose.{plugin}.yml",
+                    "up",
+                    "--no-recreate",
+                    "-d",
+                    f"{plugin}",
+                ],
+            )
+    return
+
+
 def lock(ctx, group):
     lockfile = pathlib.Path(f"~/.local/share/audius-cli/{group}.lock").expanduser()
     lockfile.parent.mkdir(parents=True, exist_ok=True)
@@ -351,6 +393,8 @@ def launch(ctx, service, seed, chain, yes):
         ],
         check=True,
     )
+
+    launch_plugins(ctx)
 
     subprocess.run(
         ["docker", "system", "prune", "--all", "--force", "--filter", "until=1h"],
@@ -711,9 +755,12 @@ def upgrade(ctx, branch):
                 ],
             )
 
+    launch_plugins(ctx)
+
     subprocess.run(
         ["docker", "system", "prune", "--all", "--force", "--filter", "until=1h"],
     )
+
 
 
 @cli.command()
@@ -894,6 +941,7 @@ def plugin_deregister(ctx, name):
     plugins = ",".join(plugins)
     dotenv.set_key(override_env, REGISTERED_PLUGINS, plugins)
     return
+
 
 @cli.command()
 @click.pass_context

--- a/audius-cli
+++ b/audius-cli
@@ -866,14 +866,15 @@ def launch_notifications(ctx):
 @click.argument("name", required=True)
 def plugin_register(ctx, name):
     print(f"registering plugin {name}")
-    plugins = dotenv.get_key(REGISTERED_PLUGINS)
+    override_env = get_override_path(ctx, "discovery-provider")
+    plugins = dotenv.get_key(override_env, REGISTERED_PLUGINS)
     if plugins is not None:
         plugins = plugins.split(",")
     else:
         plugins = []
     plugins.append(name)
     plugins = ",".join(plugins)
-    dotenv.set_key(REGISTERED_PLUGINS, plugins)
+    dotenv.set_key(override_env, REGISTERED_PLUGINS, plugins)
     return
 
 
@@ -882,7 +883,8 @@ def plugin_register(ctx, name):
 @click.argument("name", required=True)
 def plugin_deregister(ctx, name):
     print(f"deregistering plugin {name}")
-    plugins = dotenv.get_key(REGISTERED_PLUGINS)
+    override_env = get_override_path(ctx, "discovery-provider")
+    plugins = dotenv.get_key(override_env, REGISTERED_PLUGINS)
     if plugins is not None:
         plugins = plugins.split(",")
     else:
@@ -890,7 +892,7 @@ def plugin_deregister(ctx, name):
     if name in plugins:
         plugins.remove(name)
     plugins = ",".join(plugins)
-    dotenv.set_key(REGISTERED_PLUGINS, plugins)
+    dotenv.set_key(override_env, REGISTERED_PLUGINS, plugins)
     return
 
 

--- a/audius-cli
+++ b/audius-cli
@@ -79,6 +79,7 @@ def launch_plugins(ctx):
     plugins = dotenv.get_key(override_env, REGISTERED_PLUGINS)
     if plugins is not None:
         plugins = plugins.split(",")
+        print(plugins)
         for plugin in plugins:
             if not plugin:
                 subprocess.run(

--- a/audius-cli
+++ b/audius-cli
@@ -79,9 +79,8 @@ def launch_plugins(ctx):
     plugins = dotenv.get_key(override_env, REGISTERED_PLUGINS)
     if plugins is not None:
         plugins = plugins.split(",")
-        print(plugins)
         for plugin in plugins:
-            if not plugin:
+            if plugin:
                 subprocess.run(
                     [
                         "docker",


### PR DESCRIPTION
### Description
Adds `audius-cli` commands to register, deregister, and view registered plugins. 
Installs them after autoupgrade so long as a valid `docker-compose.{plugin name}.yml` exists in the disc prov dir.

### Snags
Assumes plugins only hook into discprov. This won't work for identity or storage services.
