### PR TITLE
Allow recreating of chain container to allow image upgrade

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -864,7 +864,7 @@ def launch_chain(ctx):
             "--project-directory",
             ctx.obj["manifests_path"] / "discovery-provider",
             "up",
-            "--no-recreate",
+            # "--no-recreate", temporarily recreate to allow upgrading image to audius/nethermind
             "-d",
             "chain",
         ],


### PR DESCRIPTION
### Description

Will allow chain containers to upgrade to audius/nethermind. Tested on stage DN4. Confirmed upgrade worked and it's auto restarting every few mins.