### PR TITLE
Mediorum port env

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     labels:
       autoheal: "true"
     ports:
-      - "4000:4000"
+      - "${BACKEND_PORT:-4000:4000}"
     env_file:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}
@@ -113,6 +113,8 @@ services:
     restart: unless-stopped
     networks:
       - creator-node-network
+    ports:
+      - "${MEDIORUM_PORT}"
     env_file:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     labels:
       autoheal: "true"
     ports:
-      - "${BACKEND_PORT:-4000:4000}"
+      - "${BACKEND_PORT:-4000}:4000"
     env_file:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}
@@ -114,7 +114,7 @@ services:
     networks:
       - creator-node-network
     ports:
-      - "${MEDIORUM_PORT}"
+      - "${MEDIORUM_PORT:-1991}:1991"
     env_file:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}


### PR DESCRIPTION
Adds two env variables for port mapping.

On staging we can add this to `.env` to enable "mediorum first":

```
MEDIORUM_PORT='4000'
BACKEND_PORT='4001'
```