### PR TITLE
PLAT-970: use latest audius nm version

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -220,7 +220,7 @@ services:
       driver: json-file
 
   chain:
-    image: audius/nethermind:1.14.3
+    image: audius/nethermind:1.18.0
     command: --config config
     container_name: chain
     env_file:


### PR DESCRIPTION
### Description
uses latest audius nethermind version, currently running on 2 out of 5 nodes on stage and healthy