### PR TITLE
Make CN check 500 users per 90s instead of 2000 users per minute

### DIFF
--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -43,13 +43,13 @@ enforceWriteQuorum=false
 backgroundDiskCleanupDeleteEnabled=true
 
 # State machine
-stateMonitoringQueueRateLimitInterval=60000
+stateMonitoringQueueRateLimitInterval=90000
 stateMonitoringQueueRateLimitJobsPerInterval=1
 maxRecurringRequestSyncJobConcurrency=16
 maxManualRequestSyncJobConcurrency=30
 ## Snapback (legacy)
 disableSnapback=true
-snapbackUsersPerJob=2000
+snapbackUsersPerJob=500
 
 # logging
 audius_axiom_dataset=content


### PR DESCRIPTION
### Description
Env var changes that should lower the strain on Discovery's db - calls to `/v1/full/users/content_node/all` happen less frequently and with a lower batch size. Will also cause fewer replica set updates to happen.