### PR TITLE
Add chain auto restart and remove block production from health

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -864,11 +864,12 @@ def launch_chain(ctx):
             "--project-directory",
             ctx.obj["manifests_path"] / "discovery-provider",
             "up",
-            # "--no-recreate", temporarily recreate to allow upgrading image to audius/nethermind
+            "--force-recreate",  # temporarily recreate to allow upgrading
             "-d",
             "chain",
         ],
     )
+    print("launched chain")
 
 
 @cli.command()

--- a/discovery-provider/chain/config.cfg
+++ b/discovery-provider/chain/config.cfg
@@ -16,7 +16,6 @@
     "HealthChecks": {
         "Enabled": true,
         "MaxIntervalWithoutProcessedBlock": 15,
-        "MaxIntervalWithoutProducedBlock": 45
     },
     "JsonRpc": {
         "Enabled": true,

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -245,8 +245,6 @@ services:
       - ./chain/NLog.config:/nethermind/NLog.config
       - /var/k8s/discovery-provider-chain/db/clique:/nethermind/nethermind_db/clique
       - /var/k8s/discovery-provider-chain/keystore:/nethermind/keystore
-    labels:
-      autoheal: "true"
     ports:
       - "30300:30300"
       - "30300:30300/udp"

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -221,6 +221,13 @@ services:
 
   chain:
     image: audius/nethermind:1.14.3
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl --fail localhost:8545/health || exit 1"
+        ]
     command: --config config
     container_name: chain
     env_file:


### PR DESCRIPTION
### Description

Auto restart was removed because it would continuously restart because of block production config. With block production removed from health, non signers will be considered healthy and chain will restart when it stops processing blocks.

Tested on stage.
