### PR TITLE
Add chain ID to identity env

### DIFF
--- a/identity-service/prod.env
+++ b/identity-service/prod.env
@@ -3,6 +3,7 @@ dbUrl=postgres://postgres:postgres@db:5432/postgres
 redisHost=cache
 redisPort=6379
 
+acdcChainId=31524
 aaoAddress=0x9811BA3eAB1F2Cd9A2dFeDB19e8c2a69729DC8b6
 aaoEndpoint=https://antiabuseoracle.audius.co
 generalAdmissionAddress=https://general-admission.audius.co

--- a/identity-service/stage.env
+++ b/identity-service/stage.env
@@ -3,6 +3,7 @@ dbUrl=postgres://postgres:postgres@db:5432/postgres
 redisHost=cache
 redisPort=6379
 
+acdcChainId=1056801
 aaoAddress=0x00b6462e955dA5841b6D9e1E2529B830F00f31Bf
 aaoEndpoint=https://antiabuseoracle.staging.audius.co
 generalAdmissionAddress=https://general-admission.staging.audius.co


### PR DESCRIPTION
### Description

Chain ID is needed for wallet recovery in identity https://github.com/AudiusProject/audius-protocol/pull/5420/files#diff-87ec6276585346c98b198f873a683f510d0d3e17d2fc8accad6192ff41a13f5aR198

Chain ID comes from the Discovery health check https://discoveryprovider.audius.co/health_check