### PR TITLE
Remove force recreate of chain

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -858,7 +858,6 @@ def launch_chain(ctx):
             "--project-directory",
             ctx.obj["manifests_path"] / "discovery-provider",
             "up",
-            "--force-recreate",  # temporarily recreate to allow upgrading
             "-d",
             "chain",
         ],


### PR DESCRIPTION
### Description

No need to recreate chain container since we're settling on this version. Right now, the chain container is recreating every hour with auto-upgrade. This will just leave it running.