### PR TITLE
caddy reverse proxy setup

### DIFF
--- a/creator-node/Caddyfile
+++ b/creator-node/Caddyfile
@@ -1,0 +1,7 @@
+{$HOST_NAME}
+
+{$CADDY_TLS}
+
+encode zstd gzip
+
+reverse_proxy mediorum:1991

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -140,5 +140,25 @@ services:
         max-buffer-size: 100m
       driver: json-file
 
+  caddy:
+    image: caddy
+    container_name: caddy
+    restart: unless-stopped
+    env_file:
+      - ${OVERRIDE_PATH:-override.env}
+    networks:
+      - creator-node-network
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+
 networks:
   creator-node-network:
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -1,0 +1,7 @@
+{$HOST_NAME}
+
+{$CADDY_TLS}
+
+encode zstd gzip
+
+reverse_proxy backend:5000

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -259,9 +259,26 @@ services:
         max-buffer-size: 100m
       driver: json-file
 
+  caddy:
+    image: caddy
+    container_name: caddy
+    restart: unless-stopped
+    env_file:
+      - ${OVERRIDE_PATH:-override.env}
+    networks:
+      - discovery-provider-network
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+
 networks:
   discovery-provider-network:
 
-
 volumes:
   esdata:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
Adds caddy container to make it easy to do letsencrypt (if not using cloudflare proxy) or self signed cert (if using cloudflare proxy).

This can remove the need for external ssl termination in a load balancer or similar.

Using `audius-cli`

```sh
audius-cli set-config creator-node HOST_NAME 'my.coolhost.com'

# if you are using cloudflare proxy in full mode (default), 
# tell caddy to use a self-signed cert
audius-cli set-config creator-node CADDY_TLS 'tls internal'
```

or if editing override directly:

```sh
HOST_NAME='my.coolhost.com'

# if you are using cloudflare proxy
CADDY_TLS='tls internal'
```
