### PR TITLE
Allow mediorum to write legacy fs

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -129,7 +129,7 @@ services:
       - ${OVERRIDE_PATH:-override.env}
     volumes:
       - /var/k8s/mediorum:/tmp/mediorum
-      - /var/k8s/creator-node-backend:/file_storage:ro # share fs with node.js app... ro mode for safety
+      - /var/k8s/creator-node-backend:/file_storage
     environment:
       - LOGSPOUT=ignore
     logging:


### PR DESCRIPTION
### Description
Mediorum needs to be able to delete from the legacy creator node's filesystem in order to migrate Qm CIDs to the CDK/v2 bucket.
