### PR TITLE
[PLAT-1010] Unset any override TAG envs before auto-upgrade

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -724,6 +724,14 @@ def auto_upgrade(ctx, remove, cron_expression):
 
         if not remove:
             log_file = ctx.obj["manifests_path"] / "auto-upgrade.log"
+
+            try:
+                open(log_file, "x").close()
+            except FileExistsError:
+                pass
+            except:
+                logging.warn(f"Unable to create `{log_file}` file")
+            
             job = cron.new(
                 (
                     f"date >> {log_file};"


### PR DESCRIPTION
### Description

Changes current behavior such that cron upgrades will clobber any previous calls to `audius-cli set-tag`.

#### Why

Prevent autonomously upgrading nodes from being stuck on a version.