### PR TITLE
Return 200 for unregistered nodes in health check

### DIFF
--- a/utilities/creator-node/healthChecks.js
+++ b/utilities/creator-node/healthChecks.js
@@ -27,7 +27,7 @@ function parseEnvVarsAndArgs () {
 
 async function healthCheck () {
   let requestConfig = {
-    url: `${CREATOR_NODE_ENDPOINT}/health_check`,
+    url: `${CREATOR_NODE_ENDPOINT}/health_check?allow_unregistered=true`,
     method: 'get',
     responseType: 'json'
   }


### PR DESCRIPTION
Uses the `allow_unregistered` queryparam from https://github.com/AudiusProject/audius-protocol/pull/5741