### PR TITLE
[CON-806] Add back updated delist script

### DIFF
--- a/utilities/README.md
+++ b/utilities/README.md
@@ -32,6 +32,17 @@ export spId=1 # if your node is not registered, set this env var to empty
 npm run creator:health
 ```
 
+### Delist Content
+
+If you'd like to manually delist or undelist content on your node, run this script after ensuring the necessary env vars are set:
+```
+export creatorNodeEndpoint=https://creatornode.domain.co
+export delegatePrivateKey=5e468bc1b395e2eb8f3c90ef897406087b0599d139f6ca0060ba85dcc0dce8dc
+export discoveryProviderEndpoint=https://discoveryprovider.domain.co
+npm run creator:delist track 1,abcde,3
+npm run creator:undelist user 4,fghij,5
+```
+
 ## Automatic claims
 
 If you would like to automatically run claim operations whenever a new round is initiated, `claim.js` is included for your convenience in the claim folder.

--- a/utilities/creator-node/apiSigning.js
+++ b/utilities/creator-node/apiSigning.js
@@ -17,6 +17,15 @@ const generateTimestampAndSignature = (data, privateKey) => {
   return { timestamp, signature: signedResponse.signature }
 }
 
+const generateSignature = (data, privateKey) => {
+  // JSON stringify automatically removes white space given 1 param
+  const toSignStr = JSON.stringify(sortKeys(data))
+  const toSignHash = web3.utils.keccak256(toSignStr)
+  const signedResponse = web3.eth.accounts.sign(toSignHash, privateKey)
+
+  return signedResponse.signature
+}
+
 const sortKeys = x => {
   if (typeof x !== 'object' || !x) { return x }
   if (Array.isArray(x)) { return x.map(sortKeys) }
@@ -29,6 +38,7 @@ const generateTimestampAndSignatureForSPVerification = (spID, privateKey) => {
 }
 
 module.exports = {
+  generateSignature,
   generateTimestampAndSignature,
   sortKeys,
   generateTimestampAndSignatureForSPVerification

--- a/utilities/creator-node/delistContent/hashIds.js
+++ b/utilities/creator-node/delistContent/hashIds.js
@@ -1,0 +1,21 @@
+const Hashids = require('hashids/cjs')
+
+class HashIds {
+  constructor () {
+    this.HASH_SALT = 'azowernasdfoia'
+    this.MIN_LENGTH = 5
+    this.hashids = new Hashids(this.HASH_SALT, this.MIN_LENGTH)
+  }
+
+  encode (id) {
+    return this.hashids.encode([id])
+  }
+
+  decode (id) {
+    const ids = this.hashids.decode(id)
+    if (!ids.length) return null
+    return ids[0]
+  }
+}
+
+module.exports = HashIds

--- a/utilities/creator-node/delistContent/index.js
+++ b/utilities/creator-node/delistContent/index.js
@@ -1,0 +1,166 @@
+const axios = require('axios')
+const { program } = require('commander')
+const HashIds = require('./hashIds')
+const { generateSignature } = require('../apiSigning')
+
+// Required env variables
+const PRIVATE_KEY = process.env.delegatePrivateKey
+const CREATOR_NODE_ENDPOINT = process.env.creatorNodeEndpoint
+const DISCOVERY_PROVIDER_ENDPOINT = process.env.discoveryProviderEndpoint
+
+const hashIds = new HashIds()
+
+async function sendDelistRequest(entity, delisted) {
+  if (entity.trackId) entity.trackId = parseInt(entity.trackId)
+  if (entity.userId) entity.userId = parseInt(entity.userId)
+  entity = { ...entity, delisted, timestamp: Date.now() }
+  const signature = generateSignature(entity, PRIVATE_KEY)
+
+  console.log(encodeURIComponent(JSON.stringify({ signature, data: JSON.stringify(entity) })))
+  try {
+    await axios({
+      url: `${CREATOR_NODE_ENDPOINT}/delist_status/insert`,
+      method: 'post',
+      params: { signature: JSON.stringify({ signature, data: JSON.stringify(entity) }) },
+      data: entity,
+      responseType: 'json',
+      timeout: 3000,
+    })
+    console.info(`Successfully set: ${JSON.stringify(entity)}`)
+  } catch (e) {
+    console.error(`Failed to set: ${JSON.stringify(entity)} because: ${e}`)
+  }
+}
+
+const getIdType = (id) => {
+  // Check if it's a CID (either v0 or v1)
+  if ((id.startsWith('Qm') && id.length === 46) || (id.startsWith('ba') && id.length > 46)) {
+    return 'CID'
+  }
+
+  // Check if it's an encoded id (alphanumeric and not all digits)
+  if (/\D/.test(id) && /^[0-9a-zA-Z]+$/.test(id)) {
+    return 'HASH_ID'
+  }
+
+  // Check if it's a decoded id (all digits)
+  if (/^\d+$/.test(id)) {
+    return 'ID'
+  }
+
+  return 'ERR'
+}
+
+async function getTrackInfo(trackId) {
+  try {
+    const resp = await axios({
+      url: `${DISCOVERY_PROVIDER_ENDPOINT}/tracks`,
+      method: 'get',
+      params: { id: trackId },
+      responseType: 'json',
+      timeout: 3000,
+    })
+    return { trackId, trackCid: resp.data.data[0].track_cid, ownerId: resp.data.data[0].owner_id }
+  } catch (e) {
+    console.log(`Not changing delist status for track because we failed to retrieve its info (trackId: ${trackId}): ${e}`)
+  }
+}
+
+async function getTracksForUser(userId) {
+  const resp = await axios({
+    url: `${DISCOVERY_PROVIDER_ENDPOINT}/tracks`,
+    method: 'get',
+    params: { user_id: userId },
+    responseType: 'json',
+    timeout: 3000,
+  })
+
+  return resp.data.data.map((track) => {
+    return { trackId: track.track_id, trackCid: track.track_cid, ownerId: track.owner_id }
+  })
+}
+
+async function setTrackDelisted(idStr, delisted) {
+  const idType = getIdType(idStr)
+  if (idType === 'ERR' || idType === 'CID') {
+    console.error(`Invalid id: ${idStr}. Note that CIDs are not supported for delisting individual tracks.`)
+    return
+  }
+
+  const trackId = idType === 'HASH_ID' ? hashIds.decode(idStr) : idStr
+  const track = await getTrackInfo(trackId)
+  if (track) await sendDelistRequest(track, delisted)
+}
+
+async function setUserDelisted(idStr, delisted) {
+  const idType = getIdType(idStr)
+  if (idType === 'ERR' || idType === 'CID') {
+    console.error(`Invalid id: ${idStr}`)
+    return
+  }
+
+  const userId = idType === 'HASH_ID' ? hashIds.decode(idStr) : idStr
+
+  // If delisting a user, delist all of their tracks as well
+  if (delisted) {
+    for (const track of await getTracksForUser(userId)) {
+      await sendDelistRequest(track, delisted)
+    }
+  }
+
+  await sendDelistRequest({ userId }, delisted)
+}
+
+async function setAllDelisted(trackOrUser, ids, delisted) {
+  const actions = {
+    'track': setTrackDelisted,
+    'user': setUserDelisted
+  }
+  const action = actions[trackOrUser]
+  if (!action) {
+    throw new Error(`Invalid type: ${trackOrUser}. Options are 'track' or 'user'`)
+  }
+  
+  await Promise.all(ids.map(id => action(id, delisted)))
+}
+
+const COMMANDER_HELP_STRING =
+`<action> <type> <ids>
+
+// Example usage:
+// node delistContent/index.js delist track 1,7eP5n
+// node delistContent/index.js delist user 1,ML51L
+// node delistContent/index.js undelist track 1,7eP5n
+// node delistContent/index.js undelist user 1,ML51L
+`
+
+async function main() {
+  program
+    .command('delist <trackOrUser> <ids>')
+    .description(`Prevent content from being served by your content node. When delisting a user, all of their tracks will be delisted as well.`)
+    .usage(COMMANDER_HELP_STRING)
+    .action(async (trackOrUser, ids) => setAllDelisted(trackOrUser.toLowerCase(), ids.split(','), true))
+
+  program
+    .command('undelist <trackOrUser> <ids>')
+    .description(`Allow content to be served by your content node. When undelisting a user, you have to separately undelist the desired tracks.`)
+    .usage(COMMANDER_HELP_STRING)
+    .action(async (trackOrUser, ids) => setAllDelisted(trackOrUser.toLowerCase(), ids.split(','), false))
+
+  // Ensure env vars are set
+  if (!CREATOR_NODE_ENDPOINT || !PRIVATE_KEY || !DISCOVERY_PROVIDER_ENDPOINT) {
+    console.error(`Creator node endpoint [${CREATOR_NODE_ENDPOINT}], private key [${PRIVATE_KEY}], or discovery provider endpoint [${DISCOVERY_PROVIDER_ENDPOINT}] have not been exported.`)
+    process.exit(1)
+  }
+  
+  // Run the program
+  try {
+    await program.parseAsync(process.argv)
+    process.exit(0)
+  } catch (e) {
+    console.error('Error running the script:', e)
+    process.exit(1)
+  }
+}
+
+main()

--- a/utilities/creator-node/delistContent/index.js
+++ b/utilities/creator-node/delistContent/index.js
@@ -66,19 +66,20 @@ async function getTrackInfo(trackId) {
   }
 }
 
-async function getTracksForUser(userId) {
-  const resp = await axios({
-    url: `${DISCOVERY_PROVIDER_ENDPOINT}/tracks`,
-    method: 'get',
-    params: { user_id: userId },
-    responseType: 'json',
-    timeout: 3000,
-  })
+// We currently just delist the track and the user separately.
+// async function getTracksForUser(userId) {
+//   const resp = await axios({
+//     url: `${DISCOVERY_PROVIDER_ENDPOINT}/tracks`,
+//     method: 'get',
+//     params: { user_id: userId },
+//     responseType: 'json',
+//     timeout: 3000,
+//   })
 
-  return resp.data.data.map((track) => {
-    return { trackId: track.track_id, trackCid: track.track_cid, ownerId: track.owner_id }
-  })
-}
+//   return resp.data.data.map((track) => {
+//     return { trackId: track.track_id, trackCid: track.track_cid, ownerId: track.owner_id }
+//   })
+// }
 
 async function setTrackDelisted(idStr, delisted) {
   const idType = getIdType(idStr)
@@ -101,12 +102,12 @@ async function setUserDelisted(idStr, delisted) {
 
   const userId = idType === 'HASH_ID' ? hashIds.decode(idStr) : idStr
 
-  // If delisting a user, delist all of their tracks as well
-  if (delisted) {
-    for (const track of await getTracksForUser(userId)) {
-      await sendDelistRequest(track, delisted)
-    }
-  }
+  // We don't currently delist all tracks for a user, but the option is here
+  // if (delisted) {
+  //   for (const track of await getTracksForUser(userId)) {
+  //     await sendDelistRequest(track, delisted)
+  //   }
+  // }
 
   await sendDelistRequest({ userId }, delisted)
 }
@@ -137,7 +138,7 @@ const COMMANDER_HELP_STRING =
 async function main() {
   program
     .command('delist <trackOrUser> <ids>')
-    .description(`Prevent content from being served by your content node. When delisting a user, all of their tracks will be delisted as well.`)
+    .description(`Prevent content from being served by your content node.`)
     .usage(COMMANDER_HELP_STRING)
     .action(async (trackOrUser, ids) => setAllDelisted(trackOrUser.toLowerCase(), ids.split(','), true))
 

--- a/utilities/package.json
+++ b/utilities/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "discovery:health": "node discovery-provider/healthChecks.js",
     "creator:health": "node creator-node/healthChecks.js",
+    "creator:delist": " node creator-node/delistContent/index.js delist",
+    "creator:undelist": " node creator-node/delistContent/index.js undelist",
     "claim:init-round": "node claim/claim.js initiate-round --transfer-rewards-to-solana"
   },
   "dependencies": {


### PR DESCRIPTION
### Description
Nodes can delist and undelist content again using the previous script from [here](https://github.com/AudiusProject/audius-docker-compose/commit/e9d2bc0b8927693700a8042f2c4fe590c49868d6) but cleaned up a bit and made to work with the new flow. I tested delisting and udelisting users and tracks on stage CN12.

More straightforward command usage: `npm run creator:delist track 1,3,7`
vs the previous way: `npm run creator:delist -- -a add -l 1,3,7 -t track`