### PR TITLE
Pause Qm CID migration

### DIFF
--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -26,7 +26,7 @@ ethRegistryAddress=0xd976d3b4f4e22a238c1A736b6612D22f17b6f64C
 ethTokenAddress=0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998
 
 # Application
-MIGRATE_QM_CID_ITERS=-1
+MIGRATE_QM_CID_ITERS=0
 MEDIORUM_ENV=prod
 identityService=https://identityservice.audius.co
 logLevel=info


### PR DESCRIPTION
### Description
Postgres query insights are showing the crudr sweep query hanging, presumably because the ops table is now ~10M rows. This pauses the migration until we can sort that out.