### PR TITLE
Update common postgres shared_buffers from 512mb to 2gb

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -3,7 +3,7 @@ services:
     image: postgres:11.4
     shm_size: 2g
     restart: always
-    command: postgres -c shared_buffers=512MB -c max_connections=500 -c shared_preload_libraries=pg_stat_statements
+    command: postgres -c shared_buffers=2GB -c max_connections=500 -c shared_preload_libraries=pg_stat_statements
     healthcheck:
       test: ['CMD', 'pg_isready', '-U', 'postgres']
       interval: 10s


### PR DESCRIPTION
### Description

It seems to run stably, but hard to gather enough data on a sandbox discovery node 
http://34.72.186.34:5000/health_check

Looking at RDS/CloudSQL, this value is set to >25% total system memory. Setting to 2GB sets it to 12.5% of our min specs, which I think is safe. ES being the biggest memory hog uses ~15% ... and content nodes are very quiet on memory usage.
