### PR TITLE
fix indexer / server failure cycle

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -141,7 +141,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "pgrep alembic || curl -f http://server:5000/health_check || exit 1"
+          "pgrep -f pg_migrate.sh || pgrep -f celery || exit 1"
         ]
       interval: 5s
       timeout: 5s


### PR DESCRIPTION
### Description
server is 500'ing because trusted notifier delists are behind. for some reason the indexer health check depends on the server being up. delists can't progress unless the indexer is up. and we are stuck.

affected nodes:
- w3coins
- culturestake 7
- hashbeam
- stuffisup