### PR TITLE
launch plugins after prune

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -744,7 +744,6 @@ def upgrade(ctx, branch):
 
             if service == "discovery-provider":
                 ctx.invoke(launch_chain)
-                ctx.invoke(launch_required_plugins)
 
             run(
                 [
@@ -757,6 +756,9 @@ def upgrade(ctx, branch):
                     "-d",
                 ],
             )
+
+            if service == "discovery-provider":
+                ctx.invoke(launch_required_plugins)
 
     launch_plugins(ctx)
 


### PR DESCRIPTION
### Description
when auto upgrade happens the relay container gets pruned because it's launched pre-prune, this sets up the required plugins after the prune happens
