### PR TITLE
Add back caddy cache with range header in key

### DIFF
--- a/creator-node/Caddyfile
+++ b/creator-node/Caddyfile
@@ -8,6 +8,23 @@
   {$CADDY_TLS}
   encode zstd gzip
 
+  route /content/* {
+    request_header -Cache-Control
+    header Cache-Control "public, max-age=86400, must-revalidate"
+
+    cache {
+      log_level debug
+      cache_name ContentCache
+      ttl 1h
+      stale 1h
+      key {
+        headers Authorization Content-Type Range
+      }
+    }
+
+    reverse_proxy mediorum:1991
+  }
+
   reverse_proxy mediorum:1991
 }
 


### PR DESCRIPTION
### Description

Tested this on cn 8. It works, cache key is

```
ContentCache; hit; ttl=3585; key=GET-https-creatornode8.staging.audius.co-/content/QmZ5HcM7gHWAy4ermMV9U1szBm3CC85d97jbwZcxhm3sbD/150x150.jpg---bytes=0-1024
```

for https://creatornode8.staging.audius.co/content/QmZ5HcM7gHWAy4ermMV9U1szBm3CC85d97jbwZcxhm3sbD/150x150.jpg

Before this change, I was able to fetch from cache with a range request and trigger the partial image behavior. After this change, I can no longer.


We should still make this change for UX reasons https://github.com/AudiusProject/audius-protocol/pull/6028 but it doesn't work as written. Not sure why.
