### PR TITLE
[PROTO-1189] Add healthz to common services

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -53,6 +53,11 @@ services:
         max-buffer-size: 100m
       driver: json-file
 
+  healthz:
+    image: audius/healthz:${TAG:-bc28f396b2606af49c65591119454484b900cf96}
+    container_name: healthz
+    restart: unless-stopped
+
   exporter_postgres:
     image: audius/exporter-postgres:v0.10.1
     restart: always

--- a/creator-node/Caddyfile
+++ b/creator-node/Caddyfile
@@ -9,6 +9,5 @@
   encode zstd gzip
 
   reverse_proxy mediorum:1991
+  reverse_proxy /healthz* healthz
 }
-
-

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -106,6 +106,14 @@ services:
         max-buffer-size: 100m
       driver: json-file
 
+  healthz:
+    container_name: healthz
+    extends:
+      file: ../common-services.yml
+      service: healthz
+    networks:
+      - creator-node-network
+
   caddy:
     image: audius/caddy:2.7.4
     container_name: caddy

--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -6,4 +6,6 @@ encode zstd gzip
 
 reverse_proxy /comms* comms:8925
 
+reverse_proxy /healthz* healthz
+
 reverse_proxy backend:5000

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -259,6 +259,14 @@ services:
         max-buffer-size: 100m
       driver: json-file
 
+  healthz:
+    container_name: healthz
+    extends:
+      file: ../common-services.yml
+      service: healthz
+    networks:
+      - creator-node-network
+
   caddy:
     image: audius/caddy:2.7.4
     container_name: caddy


### PR DESCRIPTION
### Description

healthz will run on all nodes instead of just centrally.

Tested on staging, confirmed navigating to /healthz endpoint on local browser works, including subroutes.