### PR TITLE
Update to v0.4.9 except identity

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       - creator-node-network
 
   mediorum:
-    image: audius/mediorum:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
+    image: audius/mediorum:${TAG:-b41e8c28db4f843a7a8c6b9db685e4747f4a134a}
     container_name: mediorum
     restart: unless-stopped
     networks:

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       - creator-node-network
 
   mediorum:
-    image: audius/mediorum:${TAG:-a37b021cb88f75d72e4b46c6ac29e8a212986587}
+    image: audius/mediorum:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
     container_name: mediorum
     restart: unless-stopped
     networks:

--- a/discovery-provider/docker-compose.plugins.yml
+++ b/discovery-provider/docker-compose.plugins.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
 
   relay:
-    image: audius/relay:${TAG:-a37b021cb88f75d72e4b46c6ac29e8a212986587}
+    image: audius/relay:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
     container_name: relay
     restart: unless-stopped
     networks:
@@ -24,7 +24,7 @@ services:
       - "6001:6001"
 
   notifications:
-    image: audius/discovery-provider-notifications:${TAG:-a37b021cb88f75d72e4b46c6ac29e8a212986587}
+    image: audius/discovery-provider-notifications:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
     container_name: notifications
     restart: unless-stopped
     networks:
@@ -44,7 +44,7 @@ services:
       - "6000:6000"
 
   sla-auditor:
-    image: audius/sla-auditor:${TAG:-a37b021cb88f75d72e4b46c6ac29e8a212986587}
+    image: audius/sla-auditor:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
     container_name: sla-auditor
     restart: unless-stopped
     networks:

--- a/discovery-provider/docker-compose.plugins.yml
+++ b/discovery-provider/docker-compose.plugins.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
 
   relay:
-    image: audius/relay:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
+    image: audius/relay:${TAG:-b41e8c28db4f843a7a8c6b9db685e4747f4a134a}
     container_name: relay
     restart: unless-stopped
     networks:
@@ -24,7 +24,7 @@ services:
       - "6001:6001"
 
   notifications:
-    image: audius/discovery-provider-notifications:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
+    image: audius/discovery-provider-notifications:${TAG:-b41e8c28db4f843a7a8c6b9db685e4747f4a134a}
     container_name: notifications
     restart: unless-stopped
     networks:
@@ -44,7 +44,7 @@ services:
       - "6000:6000"
 
   sla-auditor:
-    image: audius/sla-auditor:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
+    image: audius/sla-auditor:${TAG:-b41e8c28db4f843a7a8c6b9db685e4747f4a134a}
     container_name: sla-auditor
     restart: unless-stopped
     networks:

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -89,7 +89,7 @@ services:
 
   backend:
     container_name: server
-    image: audius/discovery-provider:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
+    image: audius/discovery-provider:${TAG:-b41e8c28db4f843a7a8c6b9db685e4747f4a134a}
     restart: always
     mem_limit: "${SERVER_MEM_LIMIT:-16000000000}"
     depends_on:
@@ -118,7 +118,7 @@ services:
 
   indexer:
     container_name: indexer
-    image: audius/discovery-provider:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
+    image: audius/discovery-provider:${TAG:-b41e8c28db4f843a7a8c6b9db685e4747f4a134a}
     restart: always
     depends_on:
       db:
@@ -150,7 +150,7 @@ services:
       - discovery-provider-network
 
   seed:
-    image: audius/discovery-provider:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
+    image: audius/discovery-provider:${TAG:-b41e8c28db4f843a7a8c6b9db685e4747f4a134a}
     command: bash /usr/share/seed.sh ${NETWORK:-prod}
     env_file:
       - ${NETWORK:-prod}.env
@@ -198,7 +198,7 @@ services:
       - discovery-provider-network
 
   comms:
-    image: audius/comms:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
+    image: audius/comms:${TAG:-b41e8c28db4f843a7a8c6b9db685e4747f4a134a}
     container_name: comms
     command: discovery
     restart: unless-stopped

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -89,7 +89,7 @@ services:
 
   backend:
     container_name: server
-    image: audius/discovery-provider:${TAG:-a37b021cb88f75d72e4b46c6ac29e8a212986587}
+    image: audius/discovery-provider:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
     restart: always
     mem_limit: "${SERVER_MEM_LIMIT:-16000000000}"
     depends_on:
@@ -118,7 +118,7 @@ services:
 
   indexer:
     container_name: indexer
-    image: audius/discovery-provider:${TAG:-a37b021cb88f75d72e4b46c6ac29e8a212986587}
+    image: audius/discovery-provider:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
     restart: always
     depends_on:
       db:
@@ -150,7 +150,7 @@ services:
       - discovery-provider-network
 
   seed:
-    image: audius/discovery-provider:${TAG:-a37b021cb88f75d72e4b46c6ac29e8a212986587}
+    image: audius/discovery-provider:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
     command: bash /usr/share/seed.sh ${NETWORK:-prod}
     env_file:
       - ${NETWORK:-prod}.env
@@ -198,7 +198,7 @@ services:
       - discovery-provider-network
 
   comms:
-    image: audius/comms:${TAG:-a37b021cb88f75d72e4b46c6ac29e8a212986587}
+    image: audius/comms:${TAG:-4a66c181176241cdbac5c4f0f8e6d6b84af0226e}
     container_name: comms
     command: discovery
     restart: unless-stopped


### PR DESCRIPTION
### Description
Updates to v0.4.9, which is already out on foundation nodes. Other nodes keep reverting to this due to auto-upgrade. We'll need to sort out the proper sequencing of this when automating. Ignores identity because we haven't deployed v0.4.9 there yet.