### PR TITLE
fix plugin restarts

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -692,7 +692,6 @@ def upgrade(ctx, branch):
                     "--project-directory",
                     ctx.obj["manifests_path"] / service,
                     "up",
-                    "--remove-orphans",
                     "-d",
                 ],
             )


### PR DESCRIPTION
### Description
Since we've enabled auto upgrade on all nodes and relay is present on each one, this upgrade flag is actually removing them each time it executes. 

Things that have manifested as a result:
- pids holding the docker lock for longer than expected
- flakiness related to plugins in the form of momentary outages that seem to fix themselves
