### PR TITLE
add trpc demo as plugin

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -749,7 +749,7 @@ def launch_plugins(ctx):
     if plugins_env is not None:
         registered_plugins = list(filter(lambda x: x != '', plugins_env.split(",")))
 
-    required_plugins = ["relay"]
+    required_plugins = ["relay", "trpc"]
 
     plugins = required_plugins + registered_plugins
 

--- a/discovery-provider/docker-compose.plugins.yml
+++ b/discovery-provider/docker-compose.plugins.yml
@@ -60,7 +60,7 @@ services:
       driver: json-file
 
   trpc:
-    image: audius/trpc:${TAG:-demo}
+    image: audius/trpc:demo
     container_name: trpc
     restart: unless-stopped
     networks:

--- a/discovery-provider/docker-compose.plugins.yml
+++ b/discovery-provider/docker-compose.plugins.yml
@@ -59,6 +59,25 @@ services:
         max-buffer-size: 100m
       driver: json-file
 
+  trpc:
+    image: audius/trpc:${TAG:-demo}
+    container_name: trpc
+    restart: unless-stopped
+    networks:
+      - dn-network
+    env_file:
+      - ${NETWORK:-prod}.env
+      - ${OVERRIDE_PATH:-override.env}
+    logging:
+      options:
+        max-size: 10m
+        max-file: 3
+        mode: non-blocking
+        max-buffer-size: 100m
+      driver: json-file
+    ports:
+      - "2022:2022"
+
 networks:
   dn-network:
     name: discovery-provider_discovery-provider-network


### PR DESCRIPTION
### Description
a number of stage nodes couldn't start up because trpc was not present for nginx
`nginx: [emerg] host not found in upstream "trpc" in /usr/local/openresty/conf/nginx.conf:274`

this adds the trpc demo as a plugin to satisfy that