### PR TITLE
move relay into main compose file

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -751,10 +751,6 @@ def launch_plugins(ctx):
         registered_plugins = list(filter(lambda x: x not in ('', 'acdc-blockscout'), plugins_env.split(",")))
         launch_blockscout = "acdc-blockscout" in plugins_env
 
-    required_plugins = ["relay"]
-
-    plugins = required_plugins + registered_plugins
-
     run(
         [
             "docker",
@@ -783,7 +779,7 @@ def launch_plugins(ctx):
             "--no-recreate",
             "-d"
         ]
-    run_cmd.extend(plugins)
+    run_cmd.extend(registered_plugins)
     run(run_cmd)
 
     if launch_blockscout:

--- a/audius-cli
+++ b/audius-cli
@@ -751,6 +751,9 @@ def launch_plugins(ctx):
         registered_plugins = list(filter(lambda x: x not in ('', 'acdc-blockscout'), plugins_env.split(",")))
         launch_blockscout = "acdc-blockscout" in plugins_env
 
+    if not registered_plugins:
+        return
+
     run(
         [
             "docker",

--- a/discovery-provider/docker-compose.plugins.yml
+++ b/discovery-provider/docker-compose.plugins.yml
@@ -1,28 +1,6 @@
 version: "3.9"
 
 services:
-
-  relay:
-    image: audius/relay:${TAG:-28f3e68b097a3530f229e8fa23d3a35fce316c38}
-    container_name: relay
-    restart: unless-stopped
-    networks:
-      - dn-network
-    environment:
-      - ENVIRONMENT=${NETWORK}
-    env_file:
-      - ${NETWORK:-prod}.env
-      - ${OVERRIDE_PATH:-override.env}
-    logging:
-      options:
-        max-size: 10m
-        max-file: 3
-        mode: non-blocking
-        max-buffer-size: 100m
-      driver: json-file
-    ports:
-      - "6001:6001"
-
   notifications:
     image: audius/discovery-provider-notifications:${TAG:-28f3e68b097a3530f229e8fa23d3a35fce316c38}
     container_name: notifications

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -93,7 +93,7 @@ services:
     container_name: relay
     restart: unless-stopped
     networks:
-      - dn-network
+      - discovery-provider-network
     environment:
       - ENVIRONMENT=${NETWORK}
     env_file:

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -88,6 +88,27 @@ services:
     networks:
       - discovery-provider-network
 
+  relay:
+    image: audius/relay:${TAG:-28f3e68b097a3530f229e8fa23d3a35fce316c38}
+    container_name: relay
+    restart: unless-stopped
+    networks:
+      - dn-network
+    environment:
+      - ENVIRONMENT=${NETWORK}
+    env_file:
+      - ${NETWORK:-prod}.env
+      - ${OVERRIDE_PATH:-override.env}
+    logging:
+      options:
+        max-size: 10m
+        max-file: 3
+        mode: non-blocking
+        max-buffer-size: 100m
+      driver: json-file
+    ports:
+      - "6001:6001"
+
   backend:
     container_name: server
     image: audius/discovery-provider:${TAG:-28f3e68b097a3530f229e8fa23d3a35fce316c38}


### PR DESCRIPTION
### Description
This PR moves relay into the main discovery compose since it's a "required" service and sets the precedent that all services in docker-compose.plugins.yml are optional. I think we can more cleanly achieve the latter using docker profiles.

Tested on stage dn2.