### PR TITLE
Add protocol dashboard as discovery plugin

### DIFF
--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -8,4 +8,6 @@ reverse_proxy /comms* comms:8925
 
 reverse_proxy /healthz* healthz
 
+reverse_proxy /dashboard* dashboard:5173
+
 reverse_proxy backend:5000

--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -8,6 +8,9 @@ reverse_proxy /comms* comms:8925
 
 reverse_proxy /healthz* healthz
 
-reverse_proxy /dashboard* dashboard:5173
+route /dashboard* {
+    redir /dashboard /dashboard/ 308
+    reverse_proxy dashboard:5173
+}
 
 reverse_proxy backend:5000

--- a/discovery-provider/docker-compose.plugins.yml
+++ b/discovery-provider/docker-compose.plugins.yml
@@ -37,6 +37,21 @@ services:
         max-buffer-size: 100m
       driver: json-file
 
+  dashboard:
+    image: audius/protocol-dashboard:${TAG:-8cda5499137d85204ba9bb4213b22e589564b0cf}
+    container_name: dashboard
+    restart: unless-stopped
+    command: ["npm", "run", "start:${NETWORK:-prod}"]
+    networks:
+      - dn-network
+    logging:
+      options:
+        max-size: 10m
+        max-file: 3
+        mode: non-blocking
+        max-buffer-size: 100m
+      driver: json-file
+
 networks:
   dn-network:
     name: discovery-provider_discovery-provider-network

--- a/discovery-provider/docker-compose.plugins.yml
+++ b/discovery-provider/docker-compose.plugins.yml
@@ -38,7 +38,7 @@ services:
       driver: json-file
 
   dashboard:
-    image: audius/dashboard:${TAG:-8cda5499137d85204ba9bb4213b22e589564b0cf}
+    image: audius/dashboard:${TAG:-54614964eaed3cbb31edadee66c8bded434fb6bf}
     container_name: dashboard
     restart: unless-stopped
     command: ["npm", "run", "start:${NETWORK:-prod}"]

--- a/discovery-provider/docker-compose.plugins.yml
+++ b/discovery-provider/docker-compose.plugins.yml
@@ -38,7 +38,7 @@ services:
       driver: json-file
 
   dashboard:
-    image: audius/protocol-dashboard:${TAG:-8cda5499137d85204ba9bb4213b22e589564b0cf}
+    image: audius/dashboard:${TAG:-8cda5499137d85204ba9bb4213b22e589564b0cf}
     container_name: dashboard
     restart: unless-stopped
     command: ["npm", "run", "start:${NETWORK:-prod}"]


### PR DESCRIPTION
### Description
Only runs as a plugin on DNs for now.

Tested on a stage node, verified dashboard was accessible at /dashboard