### PR TITLE
Recreate plugins on launch

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -804,7 +804,6 @@ def launch_plugins(ctx, service):
             / service
             / "docker-compose.plugins.yml",
             "up",
-            "--no-recreate",
             "-d"
         ]
     run_cmd.extend(registered_plugins)


### PR DESCRIPTION
Tested by doing `audius-cli upgrade` and `watch docker ps -a` on a stage CN and DN. The tags for plugins get updated, but they don't needlessly recreate when the tag is unchanged.