### PR TITLE
Lower disk usage threshold when pruning in audius-cli

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -140,7 +140,7 @@ def set_automatic_env(ctx):
 
 def prune():
     disk_usage_percent = psutil.disk_usage("/").percent
-    if disk_usage_percent > 95:
+    if disk_usage_percent > 90:
         run(
             ["docker", "system", "prune", "--all", "--force"],
         )


### PR DESCRIPTION
### Description
95% caused issues on stage DN2 last week. I think the node pulled somewhere before 95% disk util then couldn't successfully upgrade and pull after that because there was not enough space on the device. 

Prune slightly more aggressively - change threshold to 90%
