### PR TITLE
[PROTO-1388] Run protocol dashboard on prod

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -776,9 +776,8 @@ def launch_plugins(ctx, service):
         registered_plugins = list(filter(lambda x: x not in ('', 'acdc-blockscout'), plugins_env.split(",")))
         launch_blockscout = "acdc-blockscout" in plugins_env
 
-    # Make dashboard plugin always enabled
-    if "dashboard" not in registered_plugins:
-        registered_plugins.append("dashboard")
+    if not registered_plugins:
+        return
 
     run(
         [

--- a/audius-cli
+++ b/audius-cli
@@ -776,8 +776,9 @@ def launch_plugins(ctx, service):
         registered_plugins = list(filter(lambda x: x not in ('', 'acdc-blockscout'), plugins_env.split(",")))
         launch_blockscout = "acdc-blockscout" in plugins_env
 
-    if not registered_plugins:
-        return
+    # Make dashboard plugin always enabled
+    if "dashboard" not in registered_plugins:
+        registered_plugins.append("dashboard")
 
     run(
         [

--- a/creator-node/Caddyfile
+++ b/creator-node/Caddyfile
@@ -12,6 +12,8 @@
   reverse_proxy /healthz* healthz
   route /dashboard* {
       redir /dashboard /dashboard/ 308
-      reverse_proxy dashboard:5173
+      uri strip_prefix /dashboard
+      root * /dashboard-dist
+      file_server
   }
 }

--- a/creator-node/docker-compose.plugins.yml
+++ b/creator-node/docker-compose.plugins.yml
@@ -5,11 +5,17 @@ services:
     image: audius/dashboard:${TAG:-740b6e01e84274066c1683d64425303957cb0486}
     container_name: dashboard
     restart: unless-stopped
-    command: ["npm", "run", "start:${NETWORK:-prod}"]
+    command: ["sh", "-c", "npm run build:${NETWORK:-prod} && tail -f /dev/null"]
     networks:
       - cn-network
+    volumes:
+      - dashboard-dist:/app/dist
 
 networks:
   cn-network:
     name: creator-node_creator-node-network
+    external: true
+
+volumes:
+  dashboard-dist:
     external: true

--- a/creator-node/docker-compose.plugins.yml
+++ b/creator-node/docker-compose.plugins.yml
@@ -1,22 +1,8 @@
 version: "3.9"
 
 services:
-  dashboard:
-    image: audius/dashboard:${TAG:-740b6e01e84274066c1683d64425303957cb0486}
-    container_name: dashboard
-    restart: unless-stopped
-    command: ["sh", "-c", "npm run build:${NETWORK:-prod} && tail -f /dev/null"]
-    networks:
-      - cn-network
-    volumes:
-      - dashboard-dist:/app/dist
 
 networks:
   cn-network:
     name: creator-node_creator-node-network
-    external: true
-
-volumes:
-  dashboard-dist:
-    name: creator-node_dashboard-dist
     external: true

--- a/creator-node/docker-compose.plugins.yml
+++ b/creator-node/docker-compose.plugins.yml
@@ -18,4 +18,5 @@ networks:
 
 volumes:
   dashboard-dist:
+    name: creator-node_dashboard-dist
     external: true

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -129,6 +129,7 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data
       - caddy_config:/config
+      - dashboard-dist:/dashboard-dist
 
 networks:
   creator-node-network:
@@ -136,3 +137,4 @@ networks:
 volumes:
   caddy_data:
   caddy_config:
+  dashboard-dist:

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -131,6 +131,16 @@ services:
       - caddy_config:/config
       - dashboard-dist:/dashboard-dist
 
+  dashboard:
+    image: audius/dashboard:${TAG:-740b6e01e84274066c1683d64425303957cb0486}
+    container_name: dashboard
+    restart: unless-stopped
+    command: ["sh", "-c", "npm run build:${NETWORK:-prod} && tail -f /dev/null"]
+    networks:
+      - creator-node-network
+    volumes:
+      - dashboard-dist:/app/dist
+
 networks:
   creator-node-network:
 

--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -10,7 +10,9 @@ reverse_proxy /healthz* healthz
 
 route /dashboard* {
     redir /dashboard /dashboard/ 308
-    reverse_proxy dashboard:5173
+    uri strip_prefix /dashboard
+    root * /dashboard-dist
+    file_server
 }
 
 reverse_proxy backend:5000

--- a/discovery-provider/docker-compose.plugins.yml
+++ b/discovery-provider/docker-compose.plugins.yml
@@ -37,22 +37,7 @@ services:
         max-buffer-size: 100m
       driver: json-file
 
-  dashboard:
-    image: audius/dashboard:${TAG:-740b6e01e84274066c1683d64425303957cb0486}
-    container_name: dashboard
-    restart: unless-stopped
-    command: ["sh", "-c", "npm run build:${NETWORK:-prod} && tail -f /dev/null"]
-    networks:
-      - dn-network
-    volumes:
-      - dashboard-dist:/app/dist
-
 networks:
   dn-network:
     name: discovery-provider_discovery-provider-network
-    external: true
-
-volumes:
-  dashboard-dist:
-    name: discovery-provider_dashboard-dist
     external: true

--- a/discovery-provider/docker-compose.plugins.yml
+++ b/discovery-provider/docker-compose.plugins.yml
@@ -41,11 +41,17 @@ services:
     image: audius/dashboard:${TAG:-740b6e01e84274066c1683d64425303957cb0486}
     container_name: dashboard
     restart: unless-stopped
-    command: ["npm", "run", "start:${NETWORK:-prod}"]
+    command: ["sh", "-c", "npm run build:${NETWORK:-prod} && tail -f /dev/null"]
     networks:
       - dn-network
+    volumes:
+      - dashboard-dist:/app/dist
 
 networks:
   dn-network:
     name: discovery-provider_discovery-provider-network
+    external: true
+
+volumes:
+  dashboard-dist:
     external: true

--- a/discovery-provider/docker-compose.plugins.yml
+++ b/discovery-provider/docker-compose.plugins.yml
@@ -54,4 +54,5 @@ networks:
 
 volumes:
   dashboard-dist:
+    name: discovery-provider_dashboard-dist
     external: true

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -325,6 +325,16 @@ services:
       - caddy_config:/config
       - dashboard-dist:/dashboard-dist
 
+  dashboard:
+    image: audius/dashboard:${TAG:-740b6e01e84274066c1683d64425303957cb0486}
+    container_name: dashboard
+    restart: unless-stopped
+    command: ["sh", "-c", "npm run build:${NETWORK:-prod} && tail -f /dev/null"]
+    networks:
+      - discovery-provider-network
+    volumes:
+      - dashboard-dist:/app/dist
+
 networks:
   discovery-provider-network:
 

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -323,6 +323,7 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data
       - caddy_config:/config
+      - dashboard-dist:/dashboard-dist
 
 networks:
   discovery-provider-network:
@@ -331,3 +332,4 @@ volumes:
   esdata:
   caddy_data:
   caddy_config:
+  dashboard-dist:


### PR DESCRIPTION
### Description
- Runs protocol dashboard in prod (dashboard is now a core service instead of a plugin)
- Makes stage use the same build as prod (static bundle served through Caddy instead of `vite`, which is only supposed to serve in a dev environment)

### Testing
- Confirmed that this fixes the problem where the site doesn't load (blank screen) when going directly to a route (e.g., `/dashboard/#/services/content-node/12`)
- Checked out this branch on a stage CN and stage DN
