### PR TITLE
[PROTO-1409] Direct ports 4000 and 5000 through Caddy

### DIFF
--- a/creator-node/Caddyfile
+++ b/creator-node/Caddyfile
@@ -1,31 +1,31 @@
 {
-    order cache before rewrite
-    order request_header before cache
-    debug
+	order cache before rewrite
+	order request_header before cache
+	debug
 }
 
 # Snippet for common reverse proxy configuration
 (common) {
-  reverse_proxy mediorum:1991
-  reverse_proxy /healthz* healthz
-  route /dashboard* {
-    redir /dashboard /dashboard/ 308
-    uri strip_prefix /dashboard
-    root * /dashboard-dist
-    file_server
-  }
+	reverse_proxy mediorum:1991
+	reverse_proxy /healthz* healthz
+	route /dashboard* {
+		redir /dashboard /dashboard/ 308
+		uri strip_prefix /dashboard
+		root * /dashboard-dist
+		file_server
+	}
 }
 
 # Assume we're already SSL-terminated when hitting port 4000 directly
 :4000 {
-  tls internal
-  encode zstd gzip
-  import common
+	tls internal
+	encode zstd gzip
+	import common
 }
 
 # Respect TLS env var for ports 80 and 443
 {$creatorNodeEndpoint} {
-  {$CADDY_TLS}
-  encode zstd gzip
-  import common
+	{$CADDY_TLS}
+	encode zstd gzip
+	import common
 }

--- a/creator-node/Caddyfile
+++ b/creator-node/Caddyfile
@@ -16,15 +16,15 @@
   }
 }
 
-# Use the snippet for port 80 and 443. Automatic HTTPS settings are implicitly enabled
+# Use the snippet for port 80 and 443
 {$creatorNodeEndpoint}:80, {$creatorNodeEndpoint}:443 {
   {$CADDY_TLS}
   encode zstd gzip
   import common
 }
 
-# Use the snippet for port 4000 with auto_https off because SPs already SSL-terminated downstream
+# Use the snippet for port 4000, allowing SPs to handle SSL downstream in their load balancer
 {$creatorNodeEndpoint}:4000 {
-  auto_https off
+  tls off
   import common
 }

--- a/creator-node/Caddyfile
+++ b/creator-node/Caddyfile
@@ -4,7 +4,7 @@
     debug
 }
 
-# Define a snippet for common reverse proxy configuration
+# Snippet for common reverse proxy configuration
 (common) {
   reverse_proxy mediorum:1991
   reverse_proxy /healthz* healthz
@@ -16,15 +16,16 @@
   }
 }
 
-# Use the snippet for port 80 and 443
-{$creatorNodeEndpoint}:80, {$creatorNodeEndpoint}:443 {
-  {$CADDY_TLS}
+# Assume we're already SSL-terminated when hitting port 4000 directly
+:4000 {
+  tls internal
   encode zstd gzip
   import common
 }
 
-# Use the snippet for port 4000, allowing SPs to handle SSL downstream in their load balancer
-{$creatorNodeEndpoint}:4000 {
-  tls off
+# Respect TLS env var for ports 80 and 443
+{$creatorNodeEndpoint} {
+  {$CADDY_TLS}
+  encode zstd gzip
   import common
 }

--- a/creator-node/Caddyfile
+++ b/creator-node/Caddyfile
@@ -4,16 +4,27 @@
     debug
 }
 
-{$creatorNodeEndpoint} {
-  {$CADDY_TLS}
-  encode zstd gzip
-
+# Define a snippet for common reverse proxy configuration
+(common) {
   reverse_proxy mediorum:1991
   reverse_proxy /healthz* healthz
   route /dashboard* {
-      redir /dashboard /dashboard/ 308
-      uri strip_prefix /dashboard
-      root * /dashboard-dist
-      file_server
+    redir /dashboard /dashboard/ 308
+    uri strip_prefix /dashboard
+    root * /dashboard-dist
+    file_server
   }
+}
+
+# Use the snippet for port 80 and 443. Automatic HTTPS settings are implicitly enabled
+{$creatorNodeEndpoint}:80, {$creatorNodeEndpoint}:443 {
+  {$CADDY_TLS}
+  encode zstd gzip
+  import common
+}
+
+# Use the snippet for port 4000 with auto_https off because SPs already SSL-terminated downstream
+{$creatorNodeEndpoint}:4000 {
+  auto_https off
+  import common
 }

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -125,6 +125,7 @@ services:
     ports:
       - 80:80
       - 443:443
+      - 4000:4000
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -89,7 +89,7 @@ services:
     networks:
       - creator-node-network
     ports:
-      - "${MEDIORUM_PORT:-4000}:1991"
+      - "1991:1991"
       - 127.0.0.1:6060:6060
     env_file:
       - ${NETWORK:-prod}.env

--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -11,15 +11,16 @@
   reverse_proxy backend:5000
 }
 
-# Use the snippet for port 80 and 443
-{$audius_discprov_url}:80, {$audius_discprov_url}:443 {
-  {$CADDY_TLS}
+# Assume we're already SSL-terminated when hitting port 5000 directly
+:5000 {
+  tls internal
   encode zstd gzip
   import common
 }
 
-# Use the snippet for port 5000, allowing SPs to handle SSL downstream in their load balancer
-{$audius_discprov_url}:5000 {
-  auto_https off
+# Respect TLS env var for ports 80 and 443
+{$audius_discprov_url} {
+  {$CADDY_TLS}
+  encode zstd gzip
   import common
 }

--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -1,18 +1,25 @@
-{$audius_discprov_url}
-
-{$CADDY_TLS}
-
-encode zstd gzip
-
-reverse_proxy /comms* comms:8925
-
-reverse_proxy /healthz* healthz
-
-route /dashboard* {
-    redir /dashboard /dashboard/ 308
-    uri strip_prefix /dashboard
-    root * /dashboard-dist
-    file_server
+# Define a snippet for common reverse proxy configuration
+(common) {
+  reverse_proxy /comms* comms:8925
+  reverse_proxy /healthz* healthz
+  route /dashboard* {
+      redir /dashboard /dashboard/ 308
+      uri strip_prefix /dashboard
+      root * /dashboard-dist
+      file_server
+  }
+  reverse_proxy backend:1991
 }
 
-reverse_proxy backend:5000
+# Use the snippet for port 80 and 443. Automatic HTTPS settings are implicitly enabled
+{$audius_discprov_url}:80, {$audius_discprov_url}:443 {
+  {$CADDY_TLS}
+  encode zstd gzip
+  import common
+}
+
+# Use the snippet for port 5000 with auto_https off because SPs already SSL-terminated downstream
+{$audius_discprov_url}:5000 {
+  auto_https off
+  import common
+}

--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -1,26 +1,26 @@
 # Define a snippet for common reverse proxy configuration
 (common) {
-  reverse_proxy /comms* comms:8925
-  reverse_proxy /healthz* healthz
-  route /dashboard* {
-      redir /dashboard /dashboard/ 308
-      uri strip_prefix /dashboard
-      root * /dashboard-dist
-      file_server
-  }
-  reverse_proxy backend:5000
+	reverse_proxy /comms* comms:8925
+	reverse_proxy /healthz* healthz
+	route /dashboard* {
+		redir /dashboard /dashboard/ 308
+		uri strip_prefix /dashboard
+		root * /dashboard-dist
+		file_server
+	}
+	reverse_proxy backend:5000
 }
 
 # Assume we're already SSL-terminated when hitting port 5000 directly
 :5000 {
-  tls internal
-  encode zstd gzip
-  import common
+	tls internal
+	encode zstd gzip
+	import common
 }
 
 # Respect TLS env var for ports 80 and 443
 {$audius_discprov_url} {
-  {$CADDY_TLS}
-  encode zstd gzip
-  import common
+	{$CADDY_TLS}
+	encode zstd gzip
+	import common
 }

--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -8,17 +8,17 @@
       root * /dashboard-dist
       file_server
   }
-  reverse_proxy backend:1991
+  reverse_proxy backend:5000
 }
 
-# Use the snippet for port 80 and 443. Automatic HTTPS settings are implicitly enabled
+# Use the snippet for port 80 and 443
 {$audius_discprov_url}:80, {$audius_discprov_url}:443 {
   {$CADDY_TLS}
   encode zstd gzip
   import common
 }
 
-# Use the snippet for port 5000 with auto_https off because SPs already SSL-terminated downstream
+# Use the snippet for port 5000, allowing SPs to handle SSL downstream in their load balancer
 {$audius_discprov_url}:5000 {
   auto_https off
   import common

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -124,7 +124,7 @@ services:
     labels:
       autoheal: "true"
     ports:
-      - "5000:5000"
+      - "5000:1991"
     env_file:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}
@@ -319,6 +319,7 @@ services:
     ports:
       - 80:80
       - 443:443
+      - 5000:5000
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -123,8 +123,6 @@ services:
         condition: service_healthy
     labels:
       autoheal: "true"
-    ports:
-      - "5000:1991"
     env_file:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}


### PR DESCRIPTION
### Description
Most nodes are configured with a load balancer that handles TLS termination, after which requests go directly to either port 4000 or 5000. This bypasses Caddy, which is responsible for serving static assets for protocol dashboard.

This PR:
- Makes Caddy serve ports 4000 and 5000 instead of having those ports go directly to services.
- Doesn't change querying ports 80 and 443. These were and are still served by Caddy, which handles both routing and TLS termination.

### Testing
- TLS-Terminated Path (load balancer to port 4000/5000): After deploying the updated configuration on prod Content 1 and Discovery 1, the /dashboard endpoint began to load successfully. Prior to this change, the endpoint resulted in a 404 error because the traffic bypassed Caddy, which would've been responsible for serving static assets.
- Default Path (directly to port 443 handled by Caddy): The /dashboard endpoint continues to load as expected on Content 2 and Discovery 2, as well as health checks and everything else.
