### PR TITLE
rm hosts addition in server

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -98,8 +98,6 @@ services:
       - audius_elasticsearch_run_indexer=false
     networks:
       - discovery-provider-network
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
 
   indexer:
     container_name: indexer


### PR DESCRIPTION
### Description
This removes a mapping that forwards host.docker.internal to the hosts url, this messes up audius-d when working on mac. Exporters should be the only thing using this so since we removed though this change shouldn't have any effects.

tested on stage dn-3 by checking out this branch and launching discovery provider, on healthz it appears up and there doesn't seem to be any issues 
