### PR TITLE
Remove orphans on upgrade

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -713,6 +713,7 @@ def upgrade(ctx, branch):
                     "--project-directory",
                     ctx.obj["manifests_path"] / service,
                     "up",
+                    "--remove-orphans",
                     "-d",
                 ],
             )


### PR DESCRIPTION
### Description

Exporter containers are still running everywhere cuz of this.