### PR TITLE
[PROTO-1408] Add audius-cli min-version to read from chain

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -17,6 +17,12 @@ import crontab
 import dotenv
 import psutil
 
+from web3 import Web3
+
+import random
+
+from web3.providers import BaseProvider, HTTPProvider
+
 GB = 1024**3
 
 RECOMMENDED_CPU_COUNT = 8
@@ -267,6 +273,106 @@ def health_check(ctx, service):
         click.secho("Service is not healthy", fg="red")
         sys.exit(1)
 
+
+@cli.command()
+@click.argument("service", type=click.Choice(('creator-node', 'discovery-provider')))
+@click.pass_context
+def min_version(ctx, service):
+    """Check the minimum required version for a service"""
+    if service == "creator-node":
+        service = "content-node"
+    elif service == "discovery-provider":
+        service = "discovery-node"
+    
+    env = ctx.obj["manifests_path"] / service / f"{get_network(ctx, service)}.env"
+    override_env = get_override_path(ctx, service)
+
+    env_data = dotenv.dotenv_values(env)
+    override_env_data = dotenv.dotenv_values(override_env)
+
+    rpc_env_var = "audius_web3_eth_provider_url" if service == "discovery-node" else "ethProviderUrl"
+    rpc_url = override_env_data.get(rpc_env_var, env_data.get(rpc_env_var))
+    if not rpc_url:
+        click.secho(f"{rpc_env_var} env var is not set", fg="red")
+        sys.exit(1)
+    
+    eth_registry_address_env_var = "audius_eth_contracts_registry" if service == "discovery-node" else "ethRegistryAddress"
+    eth_registry_address_str = override_env_data.get(eth_registry_address_env_var, env_data.get(eth_registry_address_env_var))
+    if not eth_registry_address_str:
+        click.secho(f"{eth_registry_address_env_var} env var is not set", fg="red")
+        sys.exit(1)
+
+    eth_registry_address = Web3.toChecksumAddress(eth_registry_address_str)
+    eth_web3 = get_eth_web3(rpc_url)
+    eth_abi_values = load_eth_abi_values()
+    eth_registry_instance = eth_web3.eth.contract(
+        address=eth_registry_address, abi=eth_abi_values["Registry"]["abi"]
+    )
+    contract_address = eth_registry_instance.functions.getContract(
+        "ServiceTypeManagerProxy".encode("utf-8") # Possibly without the "Proxy"
+    ).call()
+    contract_instance = eth_web3.eth.contract(
+        address=contract_address, abi=eth_abi_values["ServiceTypeManagerProxy"]["abi"]
+    )
+    min_version = contract_instance.functions.getCurrentVersion(
+        service.encode("utf-8")
+    ).call()
+    click.secho(f"Minimum required version for {service} is {min_version}", fg="green")
+    sys.exit(0)
+
+
+def load_eth_abi_values():
+    abiDir = os.path.join(os.getcwd(), "eth-contracts", "ABIs")
+    jsonFiles = os.listdir(abiDir)
+    loaded_abi_values = {}
+    for contractJsonFile in jsonFiles:
+        fullPath = os.path.join(abiDir, contractJsonFile)
+        with open(fullPath) as f:
+            data = json.load(f)
+            loaded_abi_values[data["contractName"]] = data
+    return loaded_abi_values
+
+
+def get_eth_web3(rpc_url):
+    # pylint: disable=W0603
+    global eth_web3
+    if not eth_web3:
+        provider = MultiProvider(rpc_url)
+        for p in provider.providers:
+            p.middlewares.clear()
+        # Remove the default JSON-RPC retry middleware
+        # as it correctly cannot handle eth_getLogs block range
+        # throttle down.
+        # See https://web3py.readthedocs.io/en/stable/examples.html
+        eth_web3 = Web3(provider)
+        eth_web3.strict_bytes_type_checking = False
+        return eth_web3
+    return eth_web3
+
+
+class MultiProvider(BaseProvider):
+    """
+    Implements a custom web3 provider
+
+    ref: https://web3py.readthedocs.io/en/stable/internals.html#writing-your-own-provider
+    """
+
+    def __init__(self, providers):
+        self.providers = [HTTPProvider(provider) for provider in providers.split(",")]
+
+    def make_request(self, method, params):
+        for provider in random.sample(self.providers, k=len(self.providers)):
+            try:
+                return provider.make_request(method, params)
+            except Exception:
+                continue
+        raise Exception("All requests failed")
+
+    def isConnected(self):
+        return any(provider.isConnected() for provider in self.providers)
+
+    def __str__(self):
+        return f"MultiProvider({self.providers})"
 
 @cli.command()
 @click.option("-y", "--yes", is_flag=True)

--- a/audius-cli
+++ b/audius-cli
@@ -279,16 +279,16 @@ def health_check(ctx, service):
 @click.pass_context
 def min_version(ctx, service):
     """Check the minimum required version for a service"""
-    if service == "creator-node":
-        service = "content-node"
-    elif service == "discovery-provider":
-        service = "discovery-node"
-    
     env = ctx.obj["manifests_path"] / service / f"{get_network(ctx, service)}.env"
     override_env = get_override_path(ctx, service)
 
     env_data = dotenv.dotenv_values(env)
     override_env_data = dotenv.dotenv_values(override_env)
+
+    if service == "creator-node":
+        service = "content-node"
+    elif service == "discovery-provider":
+        service = "discovery-node"
 
     rpc_env_var = "audius_web3_eth_provider_url" if service == "discovery-node" else "ethProviderUrl"
     rpc_url = override_env_data.get(rpc_env_var, env_data.get(rpc_env_var))
@@ -302,14 +302,14 @@ def min_version(ctx, service):
         click.secho(f"{eth_registry_address_env_var} env var is not set", fg="red")
         sys.exit(1)
 
-    eth_registry_address = Web3.toChecksumAddress(eth_registry_address_str)
+    eth_registry_address = Web3.to_checksum_address(eth_registry_address_str)
     eth_web3 = get_eth_web3(rpc_url)
-    eth_abi_values = load_eth_abi_values()
+    eth_abi_values = load_eth_abi_values(os.path.join(ctx.obj["manifests_path"], "eth-contracts", "ABIs"))
     eth_registry_instance = eth_web3.eth.contract(
         address=eth_registry_address, abi=eth_abi_values["Registry"]["abi"]
     )
     contract_address = eth_registry_instance.functions.getContract(
-        "ServiceTypeManagerProxy".encode("utf-8") # Possibly without the "Proxy"
+        "ServiceTypeManagerProxy".encode("utf-8")
     ).call()
     contract_instance = eth_web3.eth.contract(
         address=contract_address, abi=eth_abi_values["ServiceTypeManagerProxy"]["abi"]
@@ -317,16 +317,15 @@ def min_version(ctx, service):
     min_version = contract_instance.functions.getCurrentVersion(
         service.encode("utf-8")
     ).call()
-    click.secho(f"Minimum required version for {service} is {min_version}", fg="green")
+    click.secho(f"Minimum required version for {service} is {min_version.decode('utf-8')}", fg="green")
     sys.exit(0)
 
 
-def load_eth_abi_values():
-    abiDir = os.path.join(os.getcwd(), "eth-contracts", "ABIs")
-    jsonFiles = os.listdir(abiDir)
+def load_eth_abi_values(abi_dir):
+    json_files = os.listdir(abi_dir)
     loaded_abi_values = {}
-    for contractJsonFile in jsonFiles:
-        fullPath = os.path.join(abiDir, contractJsonFile)
+    for contract_json_file in json_files:
+        fullPath = os.path.join(abi_dir, contract_json_file)
         with open(fullPath) as f:
             data = json.load(f)
             loaded_abi_values[data["contractName"]] = data
@@ -334,19 +333,15 @@ def load_eth_abi_values():
 
 
 def get_eth_web3(rpc_url):
-    # pylint: disable=W0603
-    global eth_web3
-    if not eth_web3:
-        provider = MultiProvider(rpc_url)
-        for p in provider.providers:
-            p.middlewares.clear()
-        # Remove the default JSON-RPC retry middleware
-        # as it correctly cannot handle eth_getLogs block range
-        # throttle down.
-        # See https://web3py.readthedocs.io/en/stable/examples.html
-        eth_web3 = Web3(provider)
-        eth_web3.strict_bytes_type_checking = False
-        return eth_web3
+    provider = MultiProvider(rpc_url)
+    for p in provider.providers:
+        p.middlewares.clear()
+    # Remove the default JSON-RPC retry middleware
+    # as it correctly cannot handle eth_getLogs block range
+    # throttle down.
+    # See https://web3py.readthedocs.io/en/stable/examples.html
+    eth_web3 = Web3(provider)
+    eth_web3.strict_bytes_type_checking = False
     return eth_web3
 
 

--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -34,7 +34,7 @@ logLevel=info
 # logging
 audius_axiom_dataset=content
 
-# /up UI
+# /d UI
 audiusUrl=https://audius.co
 queryProposalStartBlock=11818009
 gqlUri=https://gateway.thegraph.com/api/372f3681a94e4a45867d46cf59423e22/subgraphs/id/0x819fd65026848d710fe40d8c0439f1220e069398-0

--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -31,7 +31,7 @@ identityService=https://identityservice.staging.audius.co
 # logging
 audius_axiom_dataset=stage-content
 
-# /up UI
+# /d UI
 audiusUrl=https://staging.audius.co
 queryProposalStartBlock=1
 gqlUri=https://api.thegraph.com/subgraphs/name/audius-infra/audius-network-goerli

--- a/discovery-provider/prod.env
+++ b/discovery-provider/prod.env
@@ -63,7 +63,7 @@ audius_axiom_dataset=discovery
 audius_aao_endpoint=https://antiabuseoracle.audius.co
 audius_use_aao=true
 
-# /up UI
+# /d UI
 audius_url=https://audius.co
 audius_eth_network_id=1
 audius_eth_owner_wallet=0xe886a1858d2d368ef8f02c65bdd470396a1ab188

--- a/discovery-provider/stage.env
+++ b/discovery-provider/stage.env
@@ -64,7 +64,7 @@ audius_axiom_dataset=stage-discovery
 audius_aao_endpoint=https://antiabuseoracle.staging.audius.co
 audius_use_aao=false
 
-# /up UI
+# /d UI
 audius_url=https://staging.audius.co
 audius_eth_network_id=5
 audius_eth_owner_wallet=

--- a/eth-contracts/ABIs/Registry.json
+++ b/eth-contracts/ABIs/Registry.json
@@ -1,0 +1,288 @@
+{
+  "contractName": "Registry",
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_name",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_address",
+          "type": "address"
+        }
+      ],
+      "name": "ContractAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_name",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_address",
+          "type": "address"
+        }
+      ],
+      "name": "ContractRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_name",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_oldAddress",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_newAddress",
+          "type": "address"
+        }
+      ],
+      "name": "ContractUpgraded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "isOwner",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "initialize",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_name",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "_address",
+          "type": "address"
+        }
+      ],
+      "name": "addContract",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_name",
+          "type": "bytes32"
+        }
+      ],
+      "name": "removeContract",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_name",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "_newAddress",
+          "type": "address"
+        }
+      ],
+      "name": "upgradeContract",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_name",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_version",
+          "type": "uint256"
+        }
+      ],
+      "name": "getContract",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "contractAddr",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_name",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getContract",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "contractAddr",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_name",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getContractVersionCount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/eth-contracts/ABIs/ServiceTypeManager.json
+++ b/eth-contracts/ABIs/ServiceTypeManager.json
@@ -1,0 +1,337 @@
+{
+  "contractName": "ServiceTypeManagerProxy",
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_serviceType",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_serviceTypeMin",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_serviceTypeMax",
+          "type": "uint256"
+        }
+      ],
+      "name": "ServiceTypeAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_serviceType",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ServiceTypeRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_serviceType",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_serviceVersion",
+          "type": "bytes32"
+        }
+      ],
+      "name": "SetServiceVersion",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "initialize",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_governanceAddress",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getGovernanceAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_governanceAddress",
+          "type": "address"
+        }
+      ],
+      "name": "setGovernanceAddress",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_serviceType",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_serviceTypeMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_serviceTypeMax",
+          "type": "uint256"
+        }
+      ],
+      "name": "addServiceType",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_serviceType",
+          "type": "bytes32"
+        }
+      ],
+      "name": "removeServiceType",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_serviceType",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getServiceTypeInfo",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "isValid",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minStake",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxStake",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getValidServiceTypes",
+      "outputs": [
+        {
+          "internalType": "bytes32[]",
+          "name": "",
+          "type": "bytes32[]"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_serviceType",
+          "type": "bytes32"
+        }
+      ],
+      "name": "serviceTypeIsValid",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_serviceType",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_serviceVersion",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setServiceVersion",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_serviceType",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_versionIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "getVersion",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_serviceType",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getCurrentVersion",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_serviceType",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getNumberOfVersions",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_serviceType",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_serviceVersion",
+          "type": "bytes32"
+        }
+      ],
+      "name": "serviceVersionIsValid",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ click==8.1.2
 psutil==5.9.0
 python-dotenv==0.20.0
 python-crontab==2.6.0
+web3==6.6.1


### PR DESCRIPTION
### Description
Adds `audius-cli min-version [creator-node|discovery-provider]` to return the minimum enforceable version from chain.

Tested on a stage CN and DN by checking out this branch, running `sudo python3 -m pip install -r requirements.txt`, and then running `audius-cli min-version [creator-node|discovery-provider]`.

Note that new installations will already work because of install.sh calling setup.py, but to use this subcommand you must run `sudo python3 -m pip install -r requirements.txt`.