### PR TITLE
[PROTO-1458] Upgrade postgres from 11.4 to 11.22

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -1,6 +1,6 @@
 services:
   base-postgres:
-    image: postgres:11.22
+    image: postgres:11.22-bookworm
     shm_size: 2g
     restart: always
     command: postgres -c shared_buffers=2GB -c max_connections=500 -c shared_preload_libraries=pg_stat_statements


### PR DESCRIPTION
### Description
This upgrade includes a ton of security fixes (787 fixes over 4.4 years according to [this](https://why-upgrade.depesz.com/show?from=11.4&to=11.22&keywords=)), and it's a stepping stone to upgrade the major version. It's safe to upgrade this without a dump+restore because it's a minor version. I've combed the changelog and tested on discovery+content+identity.