### PR TITLE
Add metabase plugin

### DIFF
--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -1,6 +1,6 @@
 {$audius_discprov_url}
 
-{$CADDY_TLS}
+{$CADDY_TLS:localhost}
 
 encode zstd gzip
 
@@ -8,11 +8,12 @@ reverse_proxy /comms* comms:8925
 
 reverse_proxy /healthz* healthz
 
-reverse_proxy metabase:{$METABASE_PORT}
-
 route /dashboard* {
     redir /dashboard /dashboard/ 308
     uri strip_prefix /dashboard
     root * /dashboard-dist
     file_server
 }
+
+# defaults to backend:5000
+reverse_proxy {$ROOT_HOST}

--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -1,6 +1,6 @@
 {$audius_discprov_url}
 
-{$CADDY_TLS:localhost}
+{$CADDY_TLS}
 
 encode zstd gzip
 

--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -8,11 +8,11 @@ reverse_proxy /comms* comms:8925
 
 reverse_proxy /healthz* healthz
 
+reverse_proxy metabase:{$METABASE_PORT}
+
 route /dashboard* {
     redir /dashboard /dashboard/ 308
     uri strip_prefix /dashboard
     root * /dashboard-dist
     file_server
 }
-
-reverse_proxy metabase:3000

--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -16,4 +16,4 @@ route /dashboard* {
 }
 
 # defaults to backend:5000
-reverse_proxy {$ROOT_HOST}
+reverse_proxy {$ROOT_HOST:"backend:5000"}

--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -15,4 +15,4 @@ route /dashboard* {
     file_server
 }
 
-reverse_proxy backend:5000
+reverse_proxy metabase:3000

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -262,6 +262,8 @@ services:
     restart: unless-stopped
     env_file:
       - ${OVERRIDE_PATH:-override.env}
+    environment:
+      METABASE_PORT: ${METABASE_PORT:-3000}
     networks:
       - discovery-provider-network
     ports:
@@ -339,14 +341,13 @@ services:
       driver: json-file
 
   metabase:
-    image: metabase/metabase:v0.47.8
+    image: metabase/metabase:v0.48.0
     container_name: metabase
     hostname: metabase
     volumes:
       - /dev/urandom:/dev/random:ro
-    ports:
-      - 3000:3000
     environment:
+      MB_JETTY_PORT: ${METABASE_PORT:-3000}
       MB_DB_TYPE: postgres
       MB_DB_DBNAME: audius_discovery
       MB_DB_PORT: 5432
@@ -355,6 +356,8 @@ services:
       MB_DB_HOST: postgres
     networks:
       - discovery-provider-network
+    ports:
+      - "${METABASE_PORT:-3000}:${METABASE_PORT:-3000}"
     profiles:
       - metabase
     healthcheck:

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -362,6 +362,16 @@ services:
       interval: 15s
       timeout: 5s
       retries: 5
+    command: >
+      /bin/bash -c "
+      set -e;
+      export PGPASSWORD=$$MB_DB_PASS;
+      until pg_isready -h $$MB_DB_HOST -U $$MB_DB_USER; do echo 'Waiting for PostgreSQL...'; sleep 1; done;
+      if ! psql -h $$MB_DB_HOST -U $$MB_DB_USER -lqt | cut -d \| -f 1 | grep -qw $$MB_DB_DBNAME; then
+        psql -h $$MB_DB_HOST -U $$MB_DB_USER -c 'CREATE DATABASE \"$$MB_DB_DBNAME\"';
+      fi;
+      exec java -jar /app/metabase.jar
+      "
 
 networks:
   discovery-provider-network:

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -348,7 +348,7 @@ services:
       - 3000:3000
     environment:
       MB_DB_TYPE: postgres
-      MB_DB_DBNAME: audius_metabase
+      MB_DB_DBNAME: audius_discovery
       MB_DB_PORT: 5432
       MB_DB_USER: postgres
       MB_DB_PASS: postgres
@@ -362,16 +362,7 @@ services:
       interval: 15s
       timeout: 5s
       retries: 5
-    command: >
-      /bin/bash -c "
-      set -e;
-      export PGPASSWORD=$$MB_DB_PASS;
-      while ! nc -z $$MB_DB_HOST $$MB_DB_PORT; do echo 'Waiting for PostgreSQL...'; sleep 1; done;
-      if ! psql -h $$MB_DB_HOST -U $$MB_DB_USER -lqt | cut -d \| -f 1 | grep -qw $$MB_DB_DBNAME; then
-        psql -h $$MB_DB_HOST -U $$MB_DB_USER -c 'CREATE DATABASE \"$$MB_DB_DBNAME\"';
-      fi;
-      exec java -jar /app/metabase.jar
-      "
+
 
 networks:
   discovery-provider-network:

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -262,8 +262,6 @@ services:
     restart: unless-stopped
     env_file:
       - ${OVERRIDE_PATH:-override.env}
-    environment:
-      METABASE_PORT: ${METABASE_PORT:-3000}
     networks:
       - discovery-provider-network
     ports:
@@ -347,7 +345,6 @@ services:
     volumes:
       - /dev/urandom:/dev/random:ro
     environment:
-      MB_JETTY_PORT: ${METABASE_PORT:-3000}
       MB_DB_TYPE: postgres
       MB_DB_DBNAME: audius_discovery
       MB_DB_PORT: 5432
@@ -357,7 +354,7 @@ services:
     networks:
       - discovery-provider-network
     ports:
-      - "${METABASE_PORT:-3000}:${METABASE_PORT:-3000}"
+      - "3000:3000"
     profiles:
       - metabase
     healthcheck:

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -366,7 +366,7 @@ services:
       /bin/bash -c "
       set -e;
       export PGPASSWORD=$$MB_DB_PASS;
-      until pg_isready -h $$MB_DB_HOST -U $$MB_DB_USER; do echo 'Waiting for PostgreSQL...'; sleep 1; done;
+      while ! nc -z $$MB_DB_HOST $$MB_DB_PORT; do echo 'Waiting for PostgreSQL...'; sleep 1; done;
       if ! psql -h $$MB_DB_HOST -U $$MB_DB_USER -lqt | cut -d \| -f 1 | grep -qw $$MB_DB_DBNAME; then
         psql -h $$MB_DB_HOST -U $$MB_DB_USER -c 'CREATE DATABASE \"$$MB_DB_DBNAME\"';
       fi;

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -339,7 +339,7 @@ services:
       driver: json-file
 
   metabase:
-    image: metabase/metabase:latest
+    image: metabase/metabase:v0.47.8
     container_name: metabase
     hostname: metabase
     volumes:

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -338,6 +338,31 @@ services:
         max-buffer-size: 100m
       driver: json-file
 
+  metabase:
+    image: metabase/metabase:latest
+    container_name: metabase
+    hostname: metabase
+    volumes:
+      - /dev/urandom:/dev/random:ro
+    ports:
+      - 3000:3000
+    environment:
+      MB_DB_TYPE: postgres
+      MB_DB_DBNAME: audius_metabase
+      MB_DB_PORT: 5432
+      MB_DB_USER: postgres
+      MB_DB_PASS: postgres
+      MB_DB_HOST: postgres
+    networks:
+      - discovery-provider-network
+    profiles:
+      - metabase
+    healthcheck:
+      test: curl --fail -I http://localhost:3000/api/health || exit 1
+      interval: 15s
+      timeout: 5s
+      retries: 5
+
 networks:
   discovery-provider-network:
 


### PR DESCRIPTION
### Description
Introduces metabase as a plugin for running alongside a discovery node.

### Testing / Usage Instructions (on mac)
1. cd into `audius-docker-compose/discovery-provider`
2. run `docker compose --profile metabase up -d`
3. curl or go to `http://localhost` in your browser, this will show this json as you're hitting the `backend:5000` by default.
```
{
"error": [
"Route does not exist"
],
"success": false
}
```
4. install audius-cli
5. `python3 -m venv adc`, `source adc/bin/activate`
6. `cd ../`, `pip install -r requirements.txt`
7. `./audius-cli set-config discovery-provider ROOT_HOST metabase:3000`
8. `docker stop caddy`
9. `cd discovery-provider` + `docker compose --profile metabase up -d`
10. curl or go to `http://localhost` again and you should instead land on a metabase login screen (it may take a second to load, emulated image)
11. to switch it back go through steps 7-9 again but remove the config or change it to `backend:5000` and you should get your discprov server back!
12. lastly, `deactivate` your py env and `rm -rf ./adc` as it would be installed locally in `audius-docker-compose`

