### PR TITLE
[PROTO-1458] Upgrade postgres on mediorum

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -3,15 +3,92 @@ version: "3.9"
 services:
   db:
     container_name: postgres
-    extends:
-      file: ../common-services.yml
-      service: base-postgres
+    image: postgres:15.5-bookworm
+    shm_size: 2g
+    restart: always
+    entrypoint: >
+        /bin/bash -c 
+        "if [[ $$(tail -n 1 /var/lib/postgresql/data/pg_hba.conf) != 'hostnossl    all          all            0.0.0.0/0  trust' ]]; then
+          echo 'hostnossl    all          all            0.0.0.0/0  trust' >> /var/lib/postgresql/data/pg_hba.conf;
+        fi;
+        /usr/local/bin/docker-entrypoint.sh postgres -c shared_buffers=2GB -c max_connections=500 -c shared_preload_libraries=pg_stat_statements -c listen_addresses='*'"
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-U', 'postgres']
+      interval: 10s
+      timeout: 5s
+    ports:
+      - '127.0.0.1:5432:5432'
     environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
       POSTGRES_DB: audius_creator_node
+    logging:
+      options:
+        max-size: 10m
+        max-file: 3
+        mode: non-blocking
+        max-buffer-size: 100m
+      driver: json-file
     volumes:
-      - /var/k8s/creator-node-db:/var/lib/postgresql/data # Use k8s location for backward compatibility
+      - /var/k8s/creator-node-db-15:/var/lib/postgresql/data
     networks:
       - creator-node-network
+    depends_on:
+      db-upgrade:
+        condition: service_healthy
+
+  db-upgrade:
+    container_name: db-upgrade
+    image: tianon/postgres-upgrade:11-to-15
+    volumes:
+      - /var/k8s/creator-node-db:/var/lib/postgresql/11/data
+      - /var/k8s/creator-node-db-15:/var/lib/postgresql/15/data
+    environment:
+      PGBINOLD: /usr/lib/postgresql/11/bin
+      PGBINNEW: /usr/lib/postgresql/15/bin
+      PGDATAOLD: /var/lib/postgresql/11/data
+      PGDATANEW: /var/lib/postgresql/15/data
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: audius_creator_node
+    networks:
+      - creator-node-network
+    restart: "no" # Stay unhealthy (don't restart) until the upgrade is complete
+    # Healthcheck to verify completion of the upgrade
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /var/lib/postgresql/15/data/upgrade_complete"]
+      interval: 30s
+      timeout: 10s
+      retries: 1000
+    entrypoint: ["/bin/sh", "-c", "if [ ! -f /var/lib/postgresql/15/data/upgrade_complete ]; then docker-upgrade && touch /var/lib/postgresql/15/data/upgrade_complete && tail -f /dev/null; fi && tail -f /dev/null"]
+
+  db-upgrade-cleanup:
+    container_name: db-upgrade-cleanup
+    image: tianon/postgres-upgrade:11-to-15
+    volumes:
+      - /var/k8s/creator-node-db:/var/lib/postgresql/11/data
+      - /var/k8s/creator-node-db-15:/var/lib/postgresql/15/data
+    environment:
+      PGBINOLD: /usr/lib/postgresql/11/bin
+      PGBINNEW: /usr/lib/postgresql/15/bin
+      PGDATAOLD: /var/lib/postgresql/11/data
+      PGDATANEW: /var/lib/postgresql/15/data
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: audius_creator_node
+    networks:
+      - creator-node-network
+    restart: "no" # Stay unhealthy (don't restart) until the upgrade is complete
+    # Healthcheck to verify completion of the upgrade
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /var/lib/postgresql/15/data/upgrade_cleaned"]
+      interval: 30s
+      timeout: 10s
+      retries: 1000
+    entrypoint: ["/bin/sh", "-c", "if [ ! -f /var/lib/postgresql/15/data/upgrade_cleaned ]; then /usr/lib/postgresql/15/bin/vacuumdb --all --analyze-in-stages && rm -rf /var/lib/postgresql/11/data/* && touch /var/lib/postgresql/15/data/upgrade_cleaned && tail -f /dev/null; fi && tail -f /dev/null"]
+    depends_on:
+      db:
+        condition: service_healthy
 
   cache:
     container_name: redis
@@ -71,6 +148,9 @@ services:
         mode: non-blocking
         max-buffer-size: 100m
       driver: json-file
+    depends_on:
+      db:
+        condition: service_healthy
 
   healthz:
     image: audius/healthz:${TAG:-46c953e60c9e432338b0c4724bf774b921a117a5}

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 1000
-    entrypoint: ["/bin/sh", "-c", "if [ ! -f /var/lib/postgresql/15/data/upgrade_cleaned ]; then /usr/lib/postgresql/15/bin/vacuumdb --all --analyze-in-stages && rm -rf /var/lib/postgresql/11/data/* && touch /var/lib/postgresql/15/data/upgrade_cleaned && tail -f /dev/null; fi && tail -f /dev/null"]
+    entrypoint: ["/bin/sh", "-c", "if [ ! -f /var/lib/postgresql/15/data/upgrade_cleaned ]; then /usr/lib/postgresql/15/bin/vacuumdb --all --analyze-in-stages -h db -U postgres && rm -rf /var/lib/postgresql/11/data/* && touch /var/lib/postgresql/15/data/upgrade_cleaned && tail -f /dev/null; fi && tail -f /dev/null"]
     depends_on:
       db:
         condition: service_healthy

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -43,6 +43,7 @@ services:
     volumes:
       - /var/k8s/creator-node-db:/var/lib/postgresql/11/data
       - /var/k8s/creator-node-db-15:/var/lib/postgresql/15/data
+      - /var/k8s/mediorum:/tmp/mediorum
     environment:
       PGBINOLD: /usr/lib/postgresql/11/bin
       PGBINNEW: /usr/lib/postgresql/15/bin
@@ -60,7 +61,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 1000
-    entrypoint: ["/bin/sh", "-c", "if [ ! -f /var/lib/postgresql/15/data/upgrade_complete ]; then docker-upgrade && touch /var/lib/postgresql/15/data/upgrade_complete && tail -f /dev/null; fi && tail -f /dev/null"]
+    entrypoint: ["/bin/sh", "-c", "if [ ! -f /var/lib/postgresql/15/data/upgrade_complete ]; then docker-upgrade 2>&1 | tee /tmp/mediorum/pg_upgrade.txt && touch /var/lib/postgresql/15/data/upgrade_complete && tail -f /dev/null; fi && tail -f /dev/null"]
 
   db-upgrade-cleanup:
     container_name: db-upgrade-cleanup


### PR DESCRIPTION
### Description
Upgrades postgres from 11 to 15 for containerized Content Node dbs. The official docs say it's safe to upgrade directly to 16, but RDS only lets you go from 11 to 15, so maybe they know something I don't.

This automates the main steps of the upgrade:
1. Run the migration with both versions offline, using pg_upgrade (which does a lot for us)
2. Update `pg_hba.conf` so localhost can still connect - otherwise you get this error: `no pg_hba.conf entry for host, user "postgres", database, no encryption (SQLSTATE 28000)`
3. Re-build indexes (if we don't do this, query plans will be all messed up and cause slowness)
4. Drop the old data (I'll leave this part commented out on prod until after verification; we also have backups)

Note that this is only for mediorum to avoid upgrading too much at once. Discovery will come after.

### Testing

- I've tested this on all staging nodes and will do prod before merging.
- **The main concern is running out of disk space because upgrading involves duplicating the data** (healthz shows a lot of headroom for Content Nodes at least)