### PR TITLE
Bump indexer start_period to 2 hours

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -139,7 +139,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 12
-      start_period: 30m
+      start_period: 120m
     networks:
       - discovery-provider-network
 


### PR DESCRIPTION
### Description

Allows the indexer to be unhealthy for 2 hours (instead of 3 minutes) before restarting.