### PR TITLE
Perform postgres upgrade on Discovery (env var gated, off by default)

### DIFF
--- a/ADVANCED_SETUP.md
+++ b/ADVANCED_SETUP.md
@@ -46,7 +46,7 @@ The full list of variables and explanations can be found on the wiki [here](http
 ##### External Discovery Provider Postgres Instance
 If you set an external Postgres url during setup you can skip this section.
 
-The below is only if using a externally managed Postgres (version 11.1+) database:
+The below is only if using a externally managed Postgres (version 15.5+) database:
 
 ```sh
 audius-cli set-config discovery-provider

--- a/audius-cli
+++ b/audius-cli
@@ -52,6 +52,9 @@ REGISTERED_PLUGINS = "REGISTERED_PLUGINS"
 EXTRA_VANITY = "0x22466c6578692069732061207468696e6722202d204166726900000000000000"
 EXTRA_SEAL = "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 
+PG_UPGRADE_TO_VERSION = "audius_pg_upgrade_to_version"
+PG15_UPGRADE_COMPLETE = "audius_completed_upgrade_to_pg15"
+
 service_type = click.Choice(SERVICES)
 network_type = click.Choice(["prod", "stage"])
 container_type = click.Choice(["backend", "cache", "db"])
@@ -421,7 +424,7 @@ def launch(ctx, service, seed, chain, yes):
     )
 
     if seed and service == "discovery-provider":
-        # make sure backend is not running
+        # make sure services that use postgres are not running
         run(
             [
                 "docker",
@@ -429,7 +432,12 @@ def launch(ctx, service, seed, chain, yes):
                 "--project-directory",
                 ctx.obj["manifests_path"] / "discovery-provider",
                 "down",
+                "backend",
                 "indexer",
+                "trpc",
+                "comms",
+                "notifications",
+                "es-indexer",
             ],
         )
 
@@ -818,6 +826,139 @@ def upgrade(ctx, branch):
             )
 
             plugins = get_registered_plugins(ctx, service)
+
+            # ensure "audius_pg_upgrade_to_version" from override.env is reflected in .env because docker compose only sees .env
+            override_env = get_override_path(ctx, service)
+            pg_upgrade_to_version = dotenv.get_key(override_env, PG_UPGRADE_TO_VERSION)
+            if pg_upgrade_to_version:
+              dotenv.set_key(".env", PG_UPGRADE_TO_VERSION, pg_upgrade_to_version)
+            else:
+              dotenv.unset_key(".env", PG_UPGRADE_TO_VERSION)
+            pg_upgrade_complete = dotenv.get_key(override_env, PG15_UPGRADE_COMPLETE)
+
+            # upgrade postgres from v11 to v15 (gated by env var)
+            if service == "discovery-provider" and pg_upgrade_to_version == "15.5-bookworm" and pg_upgrade_complete != "true":
+                click.secho("Starting postgres upgrade from v11.22 to v15.5", fg="yellow")
+
+                # delete custom db url env vars so that we can use the default login for the new version
+                db_url = dotenv.get_key(override_env, "audius_db_url")
+                if db_url and db_url.endswith("@db:5432/audius_discovery"):
+                    dotenv.unset_key(override_env, "audius_db_url")
+                    dotenv.unset_key(override_env, "audius_db_url_read_replica")
+                    click.secho("Deleted custom db url env var(s) in override.env", fg="yellow")
+                elif db_url:
+                    click.secho("Aborting because the db is not containerized", fg="red")
+
+                # stop containers that use the db
+                click.secho("Stopping containers and deleting the existing database", fg="yellow")
+                run(
+                    [
+                        "docker",
+                        "compose",
+                        "--project-directory",
+                        ctx.obj["manifests_path"] / "discovery-provider",
+                        "down",
+                        "backend",
+                        "indexer",
+                        "trpc",
+                        "comms",
+                        "notifications",
+                        "es-indexer",
+                    ],
+                )
+
+                # delete the db volume
+                try:
+                    result = run(
+                        [
+                            "docker",
+                            "compose",
+                            "--project-directory",
+                            ctx.obj["manifests_path"] / "discovery-provider",
+                            "up",
+                            "--profile",
+                            "delete-db",
+                            "delete-db"
+                        ],
+                        check=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True
+                    )
+                    print(result.stdout)
+                    print(result.stderr)
+                except subprocess.CalledProcessError as e:
+                    click.secho(f"An error occurred: {e}", fg="red")
+                    print(e.stderr)
+
+                # bring up the db container once so it can init with the new version and default user+password
+                click.secho("Initializing Postgres v15.5 (this will take a couple minutes)", fg="yellow")
+                run(
+                    [
+                        "docker",
+                        "compose",
+                        "--project-directory",
+                        ctx.obj["manifests_path"] / "discovery-provider",
+                        "up",
+                        "-d",
+                        "db",
+                    ],
+                )
+                time.sleep(120)
+                # TODO: maybe create extensions here
+                run(
+                    [
+                        "docker",
+                        "compose",
+                        "--project-directory",
+                        ctx.obj["manifests_path"] / "discovery-provider",
+                        "down",
+                        "db",
+                    ],
+                )
+
+                # re-seed the new db
+                click.secho("Seeding the discovery provider (this will take up to an hour)", fg="yellow")
+                run(
+                    [
+                        "docker",
+                        "compose",
+                        "--project-directory",
+                        ctx.obj["manifests_path"] / "discovery-provider",
+                        "run",
+                        "seed",
+                    ],
+                )
+
+                # perform db cleanup which is necessary between major version upgrades
+                click.secho("Cleaning up the database (this will take a very long time)", fg="yellow")
+                try:
+                    result = run(
+                        [
+                            "docker",
+                            "compose",
+                            "--project-directory",
+                            ctx.obj["manifests_path"] / "discovery-provider",
+                            "up",
+                            "--profile",
+                            "optimize-db",
+                            "optimize-db"
+                        ],
+                        check=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True
+                    )
+                    print(result.stdout)
+                    print(result.stderr)
+                except subprocess.CalledProcessError as e:
+                    click.secho(f"An error occurred: {e}", fg="red")
+                    print(e.stderr)
+
+
+                # make sure we don't re-run this upgrade in the future
+                dotenv.set_key(override_env, PG15_UPGRADE_COMPLETE, "true")
+                click.secho("Upgrade complete!", fg="green")
 
             run(
                 [

--- a/audius-cli
+++ b/audius-cli
@@ -884,6 +884,7 @@ def upgrade_disc_postgres(ctx, branch):
             click.secho("Deleted custom db url env var(s) in override.env", fg="yellow")
         elif db_url:
             click.secho("Aborting because the db is not containerized", fg="red")
+            return
         
         dotenv.set_key(override_env, PG15_UPGRADE_STARTED, "true")
 
@@ -928,6 +929,7 @@ def upgrade_disc_postgres(ctx, branch):
         except subprocess.CalledProcessError as e:
             click.secho(f"An error occurred: {e}", fg="red")
             print(e.stderr)
+            return
 
         # bring up the db container once so it can init with the new version and default user+password
         click.secho("Initializing Postgres v15.5", fg="yellow")
@@ -991,25 +993,27 @@ def upgrade_disc_postgres(ctx, branch):
             
             # make sure we don't re-run this upgrade in the future
             dotenv.set_key(override_env, PG15_UPGRADE_COMPLETE, "true")
+            dotenv.unset_key(override_env, PG15_UPGRADE_STARTED)
             click.secho("Upgrade complete!", fg="green")
-
-            plugins = get_registered_plugins(ctx, "discovery-provider")
-            run(
-                [
-                    "docker",
-                    "compose",
-                    "--project-directory",
-                    ctx.obj["manifests_path"] / "discovery-provider",
-                    *plugins,
-                    "up",
-                    "--remove-orphans",
-                    "-d",
-                ],
-            )
-            ctx.invoke(launch_chain)
         except subprocess.CalledProcessError as e:
             click.secho(f"An error occurred: {e}", fg="red")
             print(e.stderr)
+            return
+    
+    plugins = get_registered_plugins(ctx, "discovery-provider")
+    run(
+        [
+            "docker",
+            "compose",
+            "--project-directory",
+            ctx.obj["manifests_path"] / "discovery-provider",
+            *plugins,
+            "up",
+            "--remove-orphans",
+            "-d",
+        ],
+    )
+    ctx.invoke(launch_chain)
 
 
 @cli.command()

--- a/audius-cli
+++ b/audius-cli
@@ -992,6 +992,21 @@ def upgrade_disc_postgres(ctx, branch):
             # make sure we don't re-run this upgrade in the future
             dotenv.set_key(override_env, PG15_UPGRADE_COMPLETE, "true")
             click.secho("Upgrade complete!", fg="green")
+
+            plugins = get_registered_plugins(ctx, "discovery-provider")
+            run(
+                [
+                    "docker",
+                    "compose",
+                    "--project-directory",
+                    ctx.obj["manifests_path"] / "discovery-provider",
+                    *plugins,
+                    "up",
+                    "--remove-orphans",
+                    "-d",
+                ],
+            )
+            ctx.invoke(launch_chain)
         except subprocess.CalledProcessError as e:
             click.secho(f"An error occurred: {e}", fg="red")
             print(e.stderr)

--- a/audius-cli
+++ b/audius-cli
@@ -53,6 +53,7 @@ EXTRA_VANITY = "0x22466c6578692069732061207468696e6722202d2041667269000000000000
 EXTRA_SEAL = "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 
 PG_UPGRADE_TO_VERSION = "audius_pg_upgrade_to_version"
+PG15_UPGRADE_STARTED = "audius_started_upgrade_to_pg15"
 PG15_UPGRADE_COMPLETE = "audius_completed_upgrade_to_pg15"
 
 service_type = click.Choice(SERVICES)
@@ -797,6 +798,12 @@ def upgrade(ctx, branch):
     ctx.forward(pull_reset)
     set_automatic_env(ctx)
 
+    # don't interrupt a postgres upgrade
+    override_env = get_override_path(ctx, "discovery-provider")
+    if dotenv.get_key(override_env, PG15_UPGRADE_STARTED) == "true":
+        click.secho("Postgres upgrade in progress. Please wait for it to complete", fg="yellow")
+        sys.exit(1)
+
     lock(ctx, "docker")
 
     for service in SERVICES:
@@ -877,6 +884,8 @@ def upgrade_disc_postgres(ctx, branch):
             click.secho("Deleted custom db url env var(s) in override.env", fg="yellow")
         elif db_url:
             click.secho("Aborting because the db is not containerized", fg="red")
+        
+        dotenv.set_key(override_env, PG15_UPGRADE_STARTED, "true")
 
         # stop containers that use the db
         click.secho("Stopping containers and deleting the existing database", fg="yellow")
@@ -934,14 +943,13 @@ def upgrade_disc_postgres(ctx, branch):
             ],
         )
         time.sleep(30)
-        # TODO: maybe create extensions here
         run(
             [
                 "docker",
                 "compose",
                 "--project-directory",
                 ctx.obj["manifests_path"] / "discovery-provider",
-                "down",
+                "stop",
                 "db",
             ],
         )

--- a/audius-cli
+++ b/audius-cli
@@ -827,138 +827,8 @@ def upgrade(ctx, branch):
 
             plugins = get_registered_plugins(ctx, service)
 
-            # ensure "audius_pg_upgrade_to_version" from override.env is reflected in .env because docker compose only sees .env
-            override_env = get_override_path(ctx, service)
-            pg_upgrade_to_version = dotenv.get_key(override_env, PG_UPGRADE_TO_VERSION)
-            if pg_upgrade_to_version:
-              dotenv.set_key(".env", PG_UPGRADE_TO_VERSION, pg_upgrade_to_version)
-            else:
-              dotenv.unset_key(".env", PG_UPGRADE_TO_VERSION)
-            pg_upgrade_complete = dotenv.get_key(override_env, PG15_UPGRADE_COMPLETE)
-
-            # upgrade postgres from v11 to v15 (gated by env var)
-            if service == "discovery-provider" and pg_upgrade_to_version == "15.5-bookworm" and pg_upgrade_complete != "true":
-                click.secho("Starting postgres upgrade from v11.22 to v15.5", fg="yellow")
-
-                # delete custom db url env vars so that we can use the default login for the new version
-                db_url = dotenv.get_key(override_env, "audius_db_url")
-                if db_url and db_url.endswith("@db:5432/audius_discovery"):
-                    dotenv.unset_key(override_env, "audius_db_url")
-                    dotenv.unset_key(override_env, "audius_db_url_read_replica")
-                    click.secho("Deleted custom db url env var(s) in override.env", fg="yellow")
-                elif db_url:
-                    click.secho("Aborting because the db is not containerized", fg="red")
-
-                # stop containers that use the db
-                click.secho("Stopping containers and deleting the existing database", fg="yellow")
-                run(
-                    [
-                        "docker",
-                        "compose",
-                        "--project-directory",
-                        ctx.obj["manifests_path"] / "discovery-provider",
-                        "down",
-                        "backend",
-                        "indexer",
-                        "trpc",
-                        "comms",
-                        "notifications",
-                        "es-indexer",
-                    ],
-                )
-
-                # delete the db volume
-                try:
-                    result = run(
-                        [
-                            "docker",
-                            "compose",
-                            "--project-directory",
-                            ctx.obj["manifests_path"] / "discovery-provider",
-                            "up",
-                            "--profile",
-                            "delete-db",
-                            "delete-db"
-                        ],
-                        check=True,
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
-                        text=True
-                    )
-                    print(result.stdout)
-                    print(result.stderr)
-                except subprocess.CalledProcessError as e:
-                    click.secho(f"An error occurred: {e}", fg="red")
-                    print(e.stderr)
-
-                # bring up the db container once so it can init with the new version and default user+password
-                click.secho("Initializing Postgres v15.5 (this will take a couple minutes)", fg="yellow")
-                run(
-                    [
-                        "docker",
-                        "compose",
-                        "--project-directory",
-                        ctx.obj["manifests_path"] / "discovery-provider",
-                        "up",
-                        "-d",
-                        "db",
-                    ],
-                )
-                time.sleep(120)
-                # TODO: maybe create extensions here
-                run(
-                    [
-                        "docker",
-                        "compose",
-                        "--project-directory",
-                        ctx.obj["manifests_path"] / "discovery-provider",
-                        "down",
-                        "db",
-                    ],
-                )
-
-                # re-seed the new db
-                click.secho("Seeding the discovery provider (this will take up to an hour)", fg="yellow")
-                run(
-                    [
-                        "docker",
-                        "compose",
-                        "--project-directory",
-                        ctx.obj["manifests_path"] / "discovery-provider",
-                        "run",
-                        "seed",
-                    ],
-                )
-
-                # perform db cleanup which is necessary between major version upgrades
-                click.secho("Cleaning up the database (this will take a very long time)", fg="yellow")
-                try:
-                    result = run(
-                        [
-                            "docker",
-                            "compose",
-                            "--project-directory",
-                            ctx.obj["manifests_path"] / "discovery-provider",
-                            "up",
-                            "--profile",
-                            "optimize-db",
-                            "optimize-db"
-                        ],
-                        check=True,
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
-                        text=True
-                    )
-                    print(result.stdout)
-                    print(result.stderr)
-                except subprocess.CalledProcessError as e:
-                    click.secho(f"An error occurred: {e}", fg="red")
-                    print(e.stderr)
-
-
-                # make sure we don't re-run this upgrade in the future
-                dotenv.set_key(override_env, PG15_UPGRADE_COMPLETE, "true")
-                click.secho("Upgrade complete!", fg="green")
+            if service == "discovery-provider":
+                ctx.forward(upgrade_disc_postgres)
 
             run(
                 [
@@ -975,8 +845,148 @@ def upgrade(ctx, branch):
 
             if service == "discovery-provider":
                 ctx.invoke(launch_chain)
+        elif service == "discovery-provider":
+            ctx.forward(upgrade_disc_postgres)
 
     prune()
+
+
+@cli.command()
+@click.argument("branch", required=False)
+@click.pass_context
+def upgrade_disc_postgres(ctx, branch):
+    """Upgrades postgres from 11 to 15 if env var is set"""
+    # ensure "audius_pg_upgrade_to_version" from override.env is reflected in .env because docker compose only sees .env
+    override_env = get_override_path(ctx, "discovery-provider")
+    pg_upgrade_to_version = dotenv.get_key(override_env, PG_UPGRADE_TO_VERSION)
+    if pg_upgrade_to_version:
+      dotenv.set_key(".env", PG_UPGRADE_TO_VERSION, pg_upgrade_to_version)
+    else:
+      dotenv.unset_key(".env", PG_UPGRADE_TO_VERSION)
+    pg_upgrade_complete = dotenv.get_key(override_env, PG15_UPGRADE_COMPLETE)
+
+    # upgrade postgres from v11 to v15 (gated by env var)
+    if pg_upgrade_to_version == "15.5-bookworm" and pg_upgrade_complete != "true":
+        click.secho("Starting postgres upgrade from v11.22 to v15.5", fg="yellow")
+
+        # delete custom db url env vars so that we can use the default login for the new version
+        db_url = dotenv.get_key(override_env, "audius_db_url")
+        if db_url and db_url.endswith("@db:5432/audius_discovery"):
+            dotenv.unset_key(override_env, "audius_db_url")
+            dotenv.unset_key(override_env, "audius_db_url_read_replica")
+            click.secho("Deleted custom db url env var(s) in override.env", fg="yellow")
+        elif db_url:
+            click.secho("Aborting because the db is not containerized", fg="red")
+
+        # stop containers that use the db
+        click.secho("Stopping containers and deleting the existing database", fg="yellow")
+        run(
+            [
+                "docker",
+                "compose",
+                "--project-directory",
+                ctx.obj["manifests_path"] / "discovery-provider",
+                "down",
+                "backend",
+                "indexer",
+                "trpc",
+                "comms",
+                "notifications",
+                "es-indexer",
+            ],
+        )
+
+        # delete the db volume
+        try:
+            result = run(
+                [
+                    "docker",
+                    "compose",
+                    "--project-directory",
+                    ctx.obj["manifests_path"] / "discovery-provider",
+                    "--profile",
+                    "delete-db",
+                    "up",
+                    "delete-db"
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True
+            )
+            print(result.stdout)
+            print(result.stderr)
+        except subprocess.CalledProcessError as e:
+            click.secho(f"An error occurred: {e}", fg="red")
+            print(e.stderr)
+
+        # bring up the db container once so it can init with the new version and default user+password
+        click.secho("Initializing Postgres v15.5", fg="yellow")
+        run(
+            [
+                "docker",
+                "compose",
+                "--project-directory",
+                ctx.obj["manifests_path"] / "discovery-provider",
+                "up",
+                "-d",
+                "db",
+            ],
+        )
+        time.sleep(30)
+        # TODO: maybe create extensions here
+        run(
+            [
+                "docker",
+                "compose",
+                "--project-directory",
+                ctx.obj["manifests_path"] / "discovery-provider",
+                "down",
+                "db",
+            ],
+        )
+
+        # re-seed the new db
+        click.secho("Seeding the discovery provider (this will take up to an hour)", fg="yellow")
+        run(
+            [
+                "docker",
+                "compose",
+                "--project-directory",
+                ctx.obj["manifests_path"] / "discovery-provider",
+                "run",
+                "seed",
+            ],
+        )
+
+        # perform db cleanup which is necessary between major version upgrades
+        click.secho("Cleaning up the database (this will take a very long time)", fg="yellow")
+        try:
+            result = run(
+                [
+                    "docker",
+                    "compose",
+                    "--project-directory",
+                    ctx.obj["manifests_path"] / "discovery-provider",
+                    "--profile",
+                    "optimize-db",
+                    "up",
+                    "optimize-db"
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True
+            )
+            print(result.stdout)
+            print(result.stderr)
+            
+            # make sure we don't re-run this upgrade in the future
+            dotenv.set_key(override_env, PG15_UPGRADE_COMPLETE, "true")
+            click.secho("Upgrade complete!", fg="green")
+        except subprocess.CalledProcessError as e:
+            click.secho(f"An error occurred: {e}", fg="red")
+            print(e.stderr)
 
 
 @cli.command()

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -60,8 +60,8 @@ services:
     # Healthcheck to verify completion of the upgrade
     healthcheck:
       test: ["CMD-SHELL", "[ -f /var/lib/postgresql/15/data/upgrade_complete ] || [ ! -d /var/lib/postgresql/11/data ] || [ ! $$(ls -A /var/lib/postgresql/11/data | wc -l) -gt 0 ]"]
-      interval: 30s
-      timeout: 10s
+      interval: 5s
+      timeout: 5s
       retries: 1000
     entrypoint: >
         /bin/sh -c
@@ -93,8 +93,8 @@ services:
     restart: "no"
     healthcheck:
       test: ["CMD-SHELL", "[ -f /var/lib/postgresql/15/data/upgrade_cleaned ] || [ ! -d /var/lib/postgresql/11/data ] || [ ! $$(ls -A /var/lib/postgresql/11/data | wc -l) -gt 0 ]"]
-      interval: 30s
-      timeout: 10s
+      interval: 5s
+      timeout: 5s
       retries: 1000
     entrypoint: >
         /bin/sh -c

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -3,15 +3,61 @@ version: "3.9"
 services:
   db:
     container_name: postgres
+    image: postgres:${audius_pg_upgrade_to_version:-11.22-bookworm}
+    shm_size: 2g
+    restart: always
+    entrypoint: >
+        /bin/bash -c 
+        "if [ -f /var/lib/postgresql/data/pg_hba.conf ]; then
+          if [[ $$(tail -n 1 /var/lib/postgresql/data/pg_hba.conf) != 'hostnossl    all          all            0.0.0.0/0  trust' ]]; then
+            echo 'hostnossl    all          all            0.0.0.0/0  trust' >> /var/lib/postgresql/data/pg_hba.conf;
+          fi;
+        fi;
+        /usr/local/bin/docker-entrypoint.sh postgres -c shared_buffers=2GB -c max_connections=500 -c shared_preload_libraries=pg_stat_statements -c listen_addresses='*'"
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-U', 'postgres']
+      interval: 10s
+      timeout: 5s
+    ports:
+      - '127.0.0.1:5432:5432'
     environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
       POSTGRES_DB: audius_discovery
-    extends:
-      file: ../common-services.yml
-      service: base-postgres
+    logging:
+      options:
+        max-size: 10m
+        max-file: 3
+        mode: non-blocking
+        max-buffer-size: 100m
+      driver: json-file
     volumes:
-      - /var/k8s/discovery-provider-db:/var/lib/postgresql/data # Use k8s location for backward compatibility
+      - /var/k8s/discovery-provider-db:/var/lib/postgresql/data
     networks:
       - discovery-provider-network
+  
+  delete-db:
+    image: alpine:latest
+    command: >
+      sh -c "rm -rf /data/* && echo 'Deletion completed' || (echo 'Error during deletion' >&2; exit 1)"
+    volumes:
+      - /var/k8s/discovery-provider-db:/data
+    profiles:
+      - delete-db
+  
+  optimize-db:
+    image: postgres:15.5-bookworm
+    environment:
+      - PGPASSWORD=postgres
+    command: >
+      sh -c "
+      psql -h db -U postgres -d audius_discovery -c 'VACUUM FULL' &&
+      psql -h db -U postgres -d audius_discovery -c 'REINDEX DATABASE audius_discovery' &&
+      psql -h db -U postgres -d audius_discovery -c 'ANALYZE' &&
+      echo 'Database optimization completed'
+      "
+    profiles:
+      - optimize-db
 
   cache:
     container_name: redis

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -51,9 +51,12 @@ services:
       - PGPASSWORD=postgres
     command: >
       sh -c "
-      psql -h db -U postgres -d audius_discovery -c 'VACUUM FULL' &&
-      psql -h db -U postgres -d audius_discovery -c 'REINDEX DATABASE audius_discovery' &&
-      psql -h db -U postgres -d audius_discovery -c 'ANALYZE' &&
+      psql -h db -U postgres -d audius_discovery -c '
+        SET autovacuum = off;
+        VACUUM FULL;
+        REINDEX DATABASE audius_discovery;
+        ANALYZE;
+      ' &&
       echo 'Database optimization completed'
       "
     networks:

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -56,6 +56,8 @@ services:
       psql -h db -U postgres -d audius_discovery -c 'ANALYZE' &&
       echo 'Database optimization completed'
       "
+    networks:
+      - discovery-provider-network
     profiles:
       - optimize-db
 


### PR DESCRIPTION
### Description

Makes `audius-cli upgrade` upgrade postgres on Discovery Nodes that use containerized dbs.

Gated by `audius_pg_upgrade_to_version` - this must equal `15.5-bookworm` in order for this upgrade to happen. It's empty by default, so we won't release this yet.

Upgrade steps (what this PR automates):
1. Stop all services
2. Delete the data in the existing db folder (audius-cli does this by calling out to a Docker container with the directory mounted. Otherwise the script wouldn't have permission)
3. Delete any custom db credentials in override.env, so it defaults to `postgres:postgres@localhost:5432/audius_discovery`
4. Start the db container with a new postgres version so it can init with default credentials, and then stop the container
5. Restore from snapshot (re-seed)
6. `VACUUM FULL`, then `REINDEX DATABASE audius_discovery`, then `ANALYZE` (took ~17 minutes on staging)
7. Set `audius_completed_upgrade_to_pg15` env var in override.env to avoid repeating this process

### Testing
I tested this multiple times on stage DN3. I'll test by manually enabling the env var on more stage nodes before making this upgrade happen by default (which will involve staggering).
