### PR TITLE
Fix using relative path to .env in pg upgrade

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -864,12 +864,13 @@ def upgrade(ctx, branch):
 def upgrade_disc_postgres(ctx, branch):
     """Upgrades postgres from 11 to 15 if env var is set"""
     # ensure "audius_pg_upgrade_to_version" from override.env is reflected in .env because docker compose only sees .env
+    env_file = ctx.obj["manifests_path"] / "discovery-provider" / ".env"
     override_env = get_override_path(ctx, "discovery-provider")
     pg_upgrade_to_version = dotenv.get_key(override_env, PG_UPGRADE_TO_VERSION)
     if pg_upgrade_to_version:
-      dotenv.set_key(".env", PG_UPGRADE_TO_VERSION, pg_upgrade_to_version)
+      dotenv.set_key(env_file, PG_UPGRADE_TO_VERSION, pg_upgrade_to_version)
     else:
-      dotenv.unset_key(".env", PG_UPGRADE_TO_VERSION)
+      dotenv.unset_key(env_file, PG_UPGRADE_TO_VERSION)
     pg_upgrade_complete = dotenv.get_key(override_env, PG15_UPGRADE_COMPLETE)
 
     # upgrade postgres from v11 to v15 (gated by env var)

--- a/audius-cli
+++ b/audius-cli
@@ -947,17 +947,7 @@ def upgrade_disc_postgres(ctx, branch):
         )
         time.sleep(30)
 
-        # bring the db back offline for seeding and double-check other services are down
-        run(
-            [
-                "docker",
-                "compose",
-                "--project-directory",
-                ctx.obj["manifests_path"] / "discovery-provider",
-                "stop",
-                "db",
-            ],
-        )
+        # double-check other services are still down
         run(
             [
                 "docker",
@@ -976,6 +966,18 @@ def upgrade_disc_postgres(ctx, branch):
         )
 
         # re-seed the new db
+        run(
+            [
+                "docker",
+                "compose",
+                "--project-directory",
+                ctx.obj["manifests_path"] / "discovery-provider",
+                "up",
+                "-d",
+                "db",
+            ],
+        )
+        time.sleep(20)
         click.secho("Seeding the discovery provider (this will take up to an hour)", fg="yellow")
         run(
             [

--- a/audius-cli
+++ b/audius-cli
@@ -907,6 +907,11 @@ def upgrade_disc_postgres(ctx, branch):
             ],
         )
 
+        # clean up in case we previously tried and ran into issues. also, the extra space won't hurt
+        run(
+            ["docker", "system", "prune", "--all", "--force"],
+        )
+
         # delete the db volume
         try:
             result = run(

--- a/audius-cli
+++ b/audius-cli
@@ -946,6 +946,8 @@ def upgrade_disc_postgres(ctx, branch):
             ],
         )
         time.sleep(30)
+
+        # bring the db back offline for seeding and double-check other services are down
         run(
             [
                 "docker",
@@ -954,6 +956,22 @@ def upgrade_disc_postgres(ctx, branch):
                 ctx.obj["manifests_path"] / "discovery-provider",
                 "stop",
                 "db",
+            ],
+        )
+        run(
+            [
+                "docker",
+                "compose",
+                "--project-directory",
+                ctx.obj["manifests_path"] / "discovery-provider",
+                "down",
+                "backend",
+                "indexer",
+                "trpc",
+                "comms",
+                "notifications",
+                "es-indexer",
+                "db"
             ],
         )
 

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -52,7 +52,6 @@ services:
     command: >
       sh -c "
       psql -h db -U postgres -d audius_discovery -c '
-        SET autovacuum = off;
         VACUUM FULL;
         REINDEX DATABASE audius_discovery;
         ANALYZE;

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -37,15 +37,19 @@ services:
       - discovery-provider-network
   
   delete-db:
+    container_name: delete-db
     image: alpine:latest
     command: >
       sh -c "rm -rf /data/* && echo 'Deletion completed' || (echo 'Error during deletion' >&2; exit 1)"
     volumes:
       - /var/k8s/discovery-provider-db:/data
+    networks:
+      - discovery-provider-network
     profiles:
       - delete-db
   
   optimize-db:
+    container_name: optimize-db
     image: postgres:15.5-bookworm
     environment:
       - PGPASSWORD=postgres

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -55,11 +55,9 @@ services:
       - PGPASSWORD=postgres
     command: >
       sh -c "
-      psql -h db -U postgres -d audius_discovery -c '
-        VACUUM FULL;
-        REINDEX DATABASE audius_discovery;
-        ANALYZE;
-      ' &&
+      psql -h db -U postgres -d audius_discovery -c 'VACUUM FULL;' &&
+      psql -h db -U postgres -d audius_discovery -c 'REINDEX DATABASE audius_discovery;' &&
+      psql -h db -U postgres -d audius_discovery -c 'ANALYZE;' &&
       echo 'Database optimization completed'
       "
     networks:


### PR DESCRIPTION
### Description
Fixes postgres upgrade for Discovery using a relative path to .env. When `audius-cli upgrade` is called via auto-upgrade (as opposed to manually), this made it set the postgres image version in `/home/ubuntu/.env` instead of `/home/ubuntu/audius-docker-compose/discovery-provider/.env`.
