### PR TITLE
Remove stale containers when pg upgrade fails

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -904,7 +904,7 @@ def upgrade_disc_postgres(ctx, branch):
                 "comms",
                 "notifications",
                 "es-indexer",
-                "db-delete",
+                "delete-db",
                 "optimize-db",
             ],
         )
@@ -969,7 +969,7 @@ def upgrade_disc_postgres(ctx, branch):
                 "notifications",
                 "es-indexer",
                 "db",
-                "db-delete",
+                "delete-db",
                 "optimize-db",
             ],
         )

--- a/audius-cli
+++ b/audius-cli
@@ -886,7 +886,7 @@ def upgrade_disc_postgres(ctx, branch):
         elif db_url:
             click.secho("Aborting because the db is not containerized", fg="red")
             return
-        
+
         dotenv.set_key(override_env, PG15_UPGRADE_STARTED, "true")
 
         # stop containers that use the db
@@ -904,6 +904,8 @@ def upgrade_disc_postgres(ctx, branch):
                 "comms",
                 "notifications",
                 "es-indexer",
+                "db-delete",
+                "optimize-db",
             ],
         )
 
@@ -966,7 +968,9 @@ def upgrade_disc_postgres(ctx, branch):
                 "comms",
                 "notifications",
                 "es-indexer",
-                "db"
+                "db",
+                "db-delete",
+                "optimize-db",
             ],
         )
 


### PR DESCRIPTION
### Description

When the postgres upgrade runs into an error, it needs to clean up the delete-db container or else it might delete, which sometimes leaves the data folder stuck in pg 11 instead of pg 15. This simple change makes it more able to restart if it runs into an error.