### PR TITLE
Improve node type detection and clean up DN containers

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -799,61 +799,99 @@ def upgrade(ctx, branch):
     set_automatic_env(ctx)
 
     # don't interrupt a postgres upgrade
-    override_env = get_override_path(ctx, "discovery-provider")
-    if dotenv.get_key(override_env, PG15_UPGRADE_STARTED) == "true":
+    identity_override_env = get_override_path(ctx, "identity-service")
+    creator_override_env = get_override_path(ctx, "creator-node")
+    disc_override_env = get_override_path(ctx, "discovery-provider")
+    if disc_override_env.exists() and dotenv.get_key(disc_override_env, PG15_UPGRADE_STARTED) == "true":
         click.secho("Postgres upgrade in progress. Please wait for it to complete", fg="yellow")
         sys.exit(1)
 
     lock(ctx, "docker")
+    
+    # determine service type based on override.env location and env vars in it
+    service = ""
+    if creator_override_env.exists() and dotenv.get_key(creator_override_env, "creatorNodeEndpoint"):
+        service = "creator-node"
+    elif identity_override_env.exists() and dotenv.get_key(identity_override_env, "ethOwnerWallet"):
+        service = "identity-service"
+    elif disc_override_env.exists() and dotenv.get_key(disc_override_env, "audius_delegate_owner_wallet"):
+        service = "discovery-provider"
+    else:
+        click.secho("Unable to determine service type. Ensure your override.env is configured", fg="yellow")
+        sys.exit(1)
+    
+    run(
+        [
+            "docker",
+            "compose",
+            "--project-directory",
+            ctx.obj["manifests_path"] / service,
+            "pull",
+        ],
+    )
 
-    for service in SERVICES:
-        proc = run(
+    plugins = get_registered_plugins(ctx, service)
+
+    if service == "discovery-provider":
+        ctx.forward(upgrade_disc_postgres)
+
+    run(
+        [
+            "docker",
+            "compose",
+            "--project-directory",
+            ctx.obj["manifests_path"] / service,
+            *plugins,
+            "up",
+            "--remove-orphans",
+            "-d",
+        ],
+    )
+
+    if service == "discovery-provider":
+        ctx.invoke(launch_chain)
+    else:
+        # clean up discovery-provider containers running in identity-service and creator-node
+        run(
             [
                 "docker",
                 "compose",
                 "--project-directory",
-                ctx.obj["manifests_path"] / service,
-                "ps",
-                "-q",
-                "mediorum" if service == "creator-node" else "backend",
+                ctx.obj["manifests_path"] / "discovery-provider",
+                "stop",
+                "chain",
             ],
-            capture_output=True,
         )
-
-        # update if service is running
-        if proc.stdout:
-            run(
-                [
-                    "docker",
-                    "compose",
-                    "--project-directory",
-                    ctx.obj["manifests_path"] / service,
-                    "pull",
-                ],
-            )
-
-            plugins = get_registered_plugins(ctx, service)
-
-            if service == "discovery-provider":
-                ctx.forward(upgrade_disc_postgres)
-
-            run(
-                [
-                    "docker",
-                    "compose",
-                    "--project-directory",
-                    ctx.obj["manifests_path"] / service,
-                    *plugins,
-                    "up",
-                    "--remove-orphans",
-                    "-d",
-                ],
-            )
-
-            if service == "discovery-provider":
-                ctx.invoke(launch_chain)
-        elif service == "discovery-provider":
-            ctx.forward(upgrade_disc_postgres)
+        run(
+            [
+                "docker",
+                "compose",
+                "--project-directory",
+                ctx.obj["manifests_path"] / "discovery-provider",
+                "down",
+            ],
+        )
+        run(
+            [
+                "docker",
+                "compose",
+                "--project-directory",
+                ctx.obj["manifests_path"] / "discovery-provider",
+                "--profile",
+                "delete-chain",
+                "up",
+                "delete-chain"
+            ],
+        )
+        run(
+            [
+                "docker",
+                "compose",
+                "--project-directory",
+                ctx.obj["manifests_path"] / "discovery-provider",
+                "down",
+            ],
+        )
 
     prune()
 
@@ -1028,22 +1066,6 @@ def upgrade_disc_postgres(ctx, branch):
         except subprocess.CalledProcessError as e:
             click.secho(f"An error occurred: {e}", fg="red")
             print(e.stderr)
-            return
-    
-    plugins = get_registered_plugins(ctx, "discovery-provider")
-    run(
-        [
-            "docker",
-            "compose",
-            "--project-directory",
-            ctx.obj["manifests_path"] / "discovery-provider",
-            *plugins,
-            "up",
-            "--remove-orphans",
-            "-d",
-        ],
-    )
-    ctx.invoke(launch_chain)
 
 
 @cli.command()

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -1,6 +1,18 @@
 version: "3.9"
 
 services:
+  delete-chain:
+    container_name: delete-chain
+    image: alpine:latest
+    command: >
+      sh -c "rm -rf /data/discovery-provider-chain && echo 'Deletion completed' || (echo 'Error during deletion' >&2; exit 1)"
+    volumes:
+      - /var/k8s:/data
+    networks:
+      - discovery-provider-network
+    profiles:
+      - delete-chain
+
   db:
     container_name: postgres
     image: postgres:${audius_pg_upgrade_to_version:-11.22-bookworm}


### PR DESCRIPTION
### Description
Makes `audius-cli upgrade` detect node type in a less error-prone and less confusing way:
1. creator-node only if creator-node/override.env exists and has `creatorNodeEndpoint` set
2. discovery-provider only if discovery-provider/override.env exists and has `audius_delegate_owner_wallet` set
3. identity-service only if identity-service/override.env is set and has `ethOwnerWallet` set

This also cleans up discovery containers that are running on identity and creator.