### PR TITLE
[PROTO-1481] Remove option to configure hosted postgres

### DIFF
--- a/ADVANCED_SETUP.md
+++ b/ADVANCED_SETUP.md
@@ -27,43 +27,10 @@ There are four required creator node environment variables, available in the cre
 
 The full list of variables and explanations can be found on the wiki [here](https://github.com/AudiusProject/audius-protocol/wiki/Content-Node:-Configuration-Details#required-environment-variables). Generally node operators will not need to modify any other environment variables
 
-##### External Creator Node Postgres
-If you set an external Postgres url during setup you can skip this section.
-
-If you did not set an external Postgres url during setup and you want to add one now, replace the db url by running:
-```sh
-audius-cli set-config creator-node
-key   : dbUrl
-value : <db url>
-```
-
 #### Discovery Provider
 There are two required discovery provider environment variables, available in the discovery provider section [here](README.md#discovery-provider).
 
 The full list of variables and explanations can be found on the wiki [here](https://github.com/AudiusProject/audius-protocol/wiki/Discovery-Node:-Configuration-Details#required-environment-variables). Generally node operators will not need to modify any other environment variables
-
-
-##### External Discovery Provider Postgres Instance
-If you set an external Postgres url during setup you can skip this section.
-
-The below is only if using a externally managed Postgres (version 15.5+) database:
-
-```sh
-audius-cli set-config discovery-provider
-key   : audius_db_url
-value : <audius_db_url>
-
-# If there's no read replica, enter the primary db url for both env vars.
-audius-cli set-config discovery-provider
-key   : audius_db_url_read_replica
-value : <audius_db_url_read_replica>
-```
-
-
-In the managed postgres database and set the `temp_file_limit` flag to `2147483647` and run the following SQL command on the destination db.
-```
-CREATE EXTENSION pg_trgm;
-```
 
 ### Launch
 ```sh

--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@ After setting the variables, they are exported to an `override.env` file in the 
 | audius_delegate_owner_wallet      | Public key for the service used to sign responses from the server. This wallet holds no tokens.     | `0x07bC80Cc29bb15a5CA3D9DB9D80AcA25eB967aFc` |
 | audius_delegate_private_key      | Private key associated with `audius_delegate_owner_wallet`    | `2ef5a28ab4c39199085eb4707d292c980fef3dcc9dc854ba8736a545c11e81c4` |
 
-
-> If you're using an externally managed Postgres DB please see [advanced setup](ADVANCED_SETUP.md#external-discovery-provider-postgres-instance)
-
 <br />
 
 ### Customizing override.env

--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -7,7 +7,6 @@ delegatePrivateKey=
 spOwnerWallet=
 
 # Infra
-dbUrl=postgres://postgres:postgres@db:5432/audius_creator_node
 dbConnectionPoolMax=400
 redisHost=cache
 redisPort=6379

--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -7,7 +7,6 @@ delegatePrivateKey=
 spOwnerWallet=
 
 # Infra
-dbUrl=postgres://postgres:postgres@db:5432/audius_creator_node
 dbConnectionPoolMax=400
 redisHost=cache
 redisPort=6379

--- a/setup.sh
+++ b/setup.sh
@@ -89,22 +89,6 @@ if [[ "$1" != "" ]]; then
 
 	audius-cli set-config --required "$1"
 
-	read -p "Are you using an externally managed Postgres? [Y/n] " -n 1 -r
-	echo
-	if [[ "$REPLY" =~ ^([Yy]|)$ ]]; then
-		read -p "Please enter db url: "
-
-		case "$1" in
-		"creator-node")
-			audius-cli set-config creator-node dbUrl "$REPLY"
-			;;
-		"discovery-provider")
-			audius-cli set-config discovery-provider audius_db_url "$REPLY"
-			audius-cli set-config discovery-provider audius_db_url_read_replica "$REPLY"
-			;;
-		esac
-	fi
-
 	read -p "Launch the service? [Y/n] " -n 1 -r
 	echo
 	if [[ "$REPLY" =~ ^([Yy]|)$ ]]; then


### PR DESCRIPTION
### Description
Removes the ability to specify a custom database URL for content nodes, along with documentation about customizing the db URL for discovery nodes. I tested this on a staging content node to ensure the environment variable is unset in the `mediorum` container and that that service runs properly anyway.
