### PR TITLE
Remove chain container when running 'audius-cli down'

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -558,6 +558,20 @@ def down(ctx, service, containers):
         services = SERVICES
 
     for service in services:
+        if not containers and service == "discovery-provider":
+            # ensure removal of the chain container
+            run(
+                [
+                    "docker",
+                    "compose",
+                    "--project-directory",
+                    ctx.obj["manifests_path"] / service,
+                    "--profile",
+                    "chain",
+                    "down",
+                ],
+            )
+
         run(
             [
                 "docker",


### PR DESCRIPTION
### Description

Expected behavior when running `audius-cli down` with no arguments is that all services and networks are removed. In the current state, the chain container and discprov network get left behind. This ensures everything is cleaned up.

### Testing

tested on stage-discovery-5