### PR TITLE
Limit mem and CPU on mediorum container

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -171,6 +171,10 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    resources:
+      limits:
+        cpus: '6' # 8 is required for all SPs, so we'll leave 2 for the OS, postgres, etc
+        memory: 14G # 16G is required for all SPs, so we'll leave 2G for the OS, postgres, etc
 
   healthz:
     image: audius/healthz:${TAG:-2109fdf8676d9925514f41d186f47ea36fa03643}

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -171,10 +171,11 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    resources:
-      limits:
-        cpus: '6' # 8 is required for all SPs, so we'll leave 2 for the OS, postgres, etc
-        memory: 14G # 16G is required for all SPs, so we'll leave 2G for the OS, postgres, etc
+    deploy:
+      resources:
+        limits:
+          cpus: '6' # 8 is required for all SPs, so we'll leave 2 for the OS, postgres, etc
+          memory: 14G # 16G is required for all SPs, so we'll leave 2G for the OS, postgres, etc
 
   healthz:
     image: audius/healthz:${TAG:-2109fdf8676d9925514f41d186f47ea36fa03643}


### PR DESCRIPTION
### Description
Goes along with https://github.com/AudiusProject/audius-protocol/pull/6988 to limit mediorum's CPU and memory to slightly under the minimum Service Provider hardware requirements. Empirically, mediorum typically runs far below these limits - see htop from a prod creator node:

<img width="1526" alt="Screenshot 2023-12-19 at 4 14 35 PM" src="https://github.com/AudiusProject/audius-docker-compose/assets/4657956/cbf730f3-ecd2-4cf7-b4c7-e44adce091f5">
