### PR TITLE
Add ddex as plugin

### DIFF
--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -15,5 +15,12 @@ route /dashboard* {
     file_server
 }
 
+route /ddex* {
+    redir /ddex /ddex/ 308
+    uri strip_prefix /ddex
+    root * /ddex-dist
+    file_server
+}
+
 # defaults to backend:5000
 reverse_proxy {$ROOT_HOST:"backend:5000"}

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -387,8 +387,21 @@ services:
       - discovery-provider-network
     volumes:
       - /var/k8s/bolt:/bolt
+    profiles:
+      - ddex
 
   # plugins
+
+  ddex:
+    image: audius/ddex:${TAG:-2109fdf8676d9925514f41d186f47ea36fa03643}
+    container_name: ddex 
+    restart: unless-stopped
+    entrypoint: "./scripts/docker-entrypoint.sh"
+    networks:
+      - discovery-provider-network
+    volumes:
+      - ddex-dist:/app/dist
+
   notifications:
     image: audius/discovery-provider-notifications:${TAG:-d04efbc2f2c58792d1a6bf19ab0747518a27c7c6}
     container_name: notifications

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -395,7 +395,6 @@ services:
     image: audius/ddex:${TAG:-2109fdf8676d9925514f41d186f47ea36fa03643}
     container_name: ddex 
     restart: unless-stopped
-    entrypoint: "./scripts/docker-entrypoint.sh"
     networks:
       - discovery-provider-network
     volumes:

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -392,7 +392,7 @@ services:
   # plugins
 
   ddex:
-    image: audius/ddex:${TAG:-2109fdf8676d9925514f41d186f47ea36fa03643}
+    image: audius/ddex:${TAG:-d04efbc2f2c58792d1a6bf19ab0747518a27c7c6}
     container_name: ddex 
     restart: unless-stopped
     networks:

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -387,8 +387,6 @@ services:
       - discovery-provider-network
     volumes:
       - /var/k8s/bolt:/bolt
-    profiles:
-      - ddex
 
   # plugins
 
@@ -401,6 +399,8 @@ services:
       - discovery-provider-network
     volumes:
       - ddex-dist:/app/dist
+    profiles:
+      - ddex
 
   notifications:
     image: audius/discovery-provider-notifications:${TAG:-d04efbc2f2c58792d1a6bf19ab0747518a27c7c6}

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -363,6 +363,7 @@ services:
       - caddy_data:/data
       - caddy_config:/config
       - dashboard-dist:/dashboard-dist
+      - ddex-dist:/ddex-dist
 
   dashboard:
     image: audius/dashboard:${TAG:-d04efbc2f2c58792d1a6bf19ab0747518a27c7c6}

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -476,3 +476,4 @@ volumes:
   caddy_data:
   caddy_config:
   dashboard-dist:
+  ddex-dist:


### PR DESCRIPTION
### Description
Run DDEX as a discovery plugin, accessible on the node at `/ddex`.
Merge after https://github.com/AudiusProject/audius-protocol/pull/6990.