### PR TITLE
[PROTO-1557] Make /ddex use container instead of pre-compiled dist

### DIFF
--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -18,8 +18,7 @@ route /dashboard* {
 route /ddex* {
     redir /ddex /ddex/ 308
     uri strip_prefix /ddex
-    root * /ddex-dist
-    file_server
+    reverse_proxy ddex:8926
 }
 
 # defaults to backend:5000

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -363,7 +363,6 @@ services:
       - caddy_data:/data
       - caddy_config:/config
       - dashboard-dist:/dashboard-dist
-      - ddex-dist:/ddex-dist
 
   dashboard:
     image: audius/dashboard:${TAG:-8c1e557aa1d629b643e4e13b2a0f4f4bc53a2d08}-${NETWORK:-prod}
@@ -396,8 +395,6 @@ services:
     restart: unless-stopped
     networks:
       - discovery-provider-network
-    volumes:
-      - ddex-dist:/app/dist
     profiles:
       - ddex
 
@@ -475,4 +472,3 @@ volumes:
   caddy_data:
   caddy_config:
   dashboard-dist:
-  ddex-dist:


### PR DESCRIPTION
### Description
Routes /ddex to a backend NodeJS server instead of serving frontend assets directly. Tested with the image from https://github.com/AudiusProject/audius-protocol/pull/7064.
