### PR TITLE
Add conditional matchers for discovery Caddy directives

### DIFF
--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -4,18 +4,34 @@
 
 encode zstd gzip
 
-reverse_proxy /comms* comms:8925
+@comms {
+    path /comms*
+    expression "{$NO_COMMS}" == ""
+}
+reverse_proxy @comms comms:8925
 
-reverse_proxy /healthz* healthz
+@healthz {
+    path /healthz*
+    expression "{$NO_HEALTHZ}" == ""
+}
+reverse_proxy @healthz healthz
 
-route /dashboard* {
+@dashboard {
+    path /dashboard*
+    expression "{$NO_DASHBOARD}" == ""
+}
+route @dashboard {
     redir /dashboard /dashboard/ 308
     uri strip_prefix /dashboard
     root * /dashboard-dist
     file_server
 }
 
-route /ddex* {
+@ddex {
+    path /ddex*
+    expression "{$NO_DDEX}" == ""
+}
+route @ddex {
     redir /ddex /ddex/ 308
     uri strip_prefix /ddex
     reverse_proxy ddex:8926


### PR DESCRIPTION
### Description

For the metabase plugin, /dashboard clobbers the namespace metabase uses for all its dashboards, thus making direct links not work. Generally speaking, we don't want people to override these configs, but in certain cases someone may want to.

This should have no impact to running nodes

*Instructions*

1. Set `NO_DASHBOARD=true` (or any non-empty value) in `discovery-provider/override.env`
2. audius-cli launch discovery-provider

Tested via `discovery-metabase` node that runs the plugin. Also confirmed that /healthz, /comms work as intended