### PR TITLE
DDEX env

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -412,6 +412,10 @@ services:
     image: audius/ddex:${TAG:-d162abc89da080cabd12f8216590820ec7973446}
     container_name: ddex
     restart: unless-stopped
+    environment:
+      - NODE_ENV=${NETWORK:-prod}
+    env_file:
+      - ${OVERRIDE_PATH:-override.env}
     networks:
       - discovery-provider-network
     profiles:


### PR DESCRIPTION
### Description
DDEX requires `OPTIMIZELY_SDK_KEY`, `DDEX_KEY`, and `DDEX_SECRET` in `override.env` on the node it's running on.
Note: changed the ddex backend to expect `prod` rather than `production` for `NODE_ENV` in https://github.com/AudiusProject/audius-protocol/pull/7103