### PR TITLE
Standalone openresty container

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -149,6 +149,18 @@ services:
     ports:
       - "6001:6001"
 
+  openresty:
+    image: audius/discovery-provider-openresty:${TAG:-c3c214844039604576033214631ae5840b0602d6}
+    container_name: openresty
+    <<: *extra-hosts
+    restart: unless-stopped
+    env_file:
+      - ${OVERRIDE_PATH:-override.env}
+    networks:
+      - discovery-provider-network
+    ports:
+      - "5000:5000"
+
   backend:
     container_name: server
     image: audius/discovery-provider:${TAG:-c3c214844039604576033214631ae5840b0602d6}
@@ -167,7 +179,7 @@ services:
     labels:
       autoheal: "true"
     ports:
-      - "5000:5000"
+      - "3000:3000"
     env_file:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}


### PR DESCRIPTION
After merge:

* de-duplicate `nginx.conf` and `nginx_container.conf`
* remove openresty stuff from `start.sh`
