### PR TITLE
Mount auto upgrade logs to vector container

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -809,10 +809,9 @@ def upgrade(ctx, branch):
     """Pulls from latest source and re-launches all running services"""
     log_file = ctx.obj["manifests_path"] / "auto-upgrade.log"
     try:
-        # Open the file in 'w' mode which clears the file
+        # clear the previous auto-upgrade logs
         open(log_file, "w").close()
     except Exception as e:
-        # Handle exception if the file cannot be cleared or accessed
         print(f"Error while clearing the log file: {e}")
 
     try:

--- a/audius-cli
+++ b/audius-cli
@@ -807,6 +807,14 @@ def pull_reset(ctx, branch):
 @click.pass_context
 def upgrade(ctx, branch):
     """Pulls from latest source and re-launches all running services"""
+    log_file = ctx.obj["manifests_path"] / "auto-upgrade.log"
+    try:
+        # Open the file in 'w' mode which clears the file
+        open(log_file, "w").close()
+    except Exception as e:
+        # Handle exception if the file cannot be cleared or accessed
+        print(f"Error while clearing the log file: {e}")
+
     try:
         ctx.forward(pull_reset)
         set_automatic_env(ctx)

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -259,7 +259,6 @@ services:
     volumes:
       - /home/ubuntu/audius-docker-compose/auto-upgrade.log:/auto-upgrade.log
 
-
   comms:
     image: audius/comms:${TAG:-f6ad76fac1432bab331ef6d100310d090308d8dd}
     container_name: comms

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -256,6 +256,9 @@ services:
       - ${OVERRIDE_PATH:-override.env}
     networks:
       - discovery-provider-network
+    volumes:
+      - /home/ubuntu/audius-docker-compose/auto-upgrade.log:/auto-upgrade.log
+
 
   comms:
     image: audius/comms:${TAG:-f6ad76fac1432bab331ef6d100310d090308d8dd}


### PR DESCRIPTION
### Description

This will allow vector to process auto upgrade logs so we can see them in axiom.

https://github.com/AudiusProject/audius-protocol/compare/is-auto-upgrade-log?expand=1