### PR TITLE
DDEX web on standalone node

### DIFF
--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -27,15 +27,5 @@ route @dashboard {
     file_server
 }
 
-@ddex {
-    path /ddex*
-    expression "{$NO_DDEX}" == ""
-}
-route @ddex {
-    redir /ddex /ddex/ 308
-    uri strip_prefix /ddex
-    reverse_proxy ddex:8926
-}
-
 # defaults to backend:5000
 reverse_proxy {$ROOT_HOST:"backend:5000"}

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -412,9 +412,9 @@ services:
 
   # === ddex ===
   
-  ddex_web:
+  ddex-web:
     image: audius/ddex:${TAG:-d5e07754095c01765ca3eb564fca710163a5f19d}
-    container_name: ddex_web
+    container_name: ddex-web
     restart: unless-stopped
     environment:
       - NODE_ENV=${NETWORK:-prod}

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -425,6 +425,11 @@ services:
       - discovery-provider-network
     ports:
       - "3000:3000"
+    healthcheck:
+      test: curl --fail -I http://localhost:3000/api/health_check || exit 1
+      interval: 15s
+      timeout: 5s
+      retries: 5
     profiles:
       - ddex
 

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -410,18 +410,25 @@ services:
 
   # plugins
 
-  ddex:
+  # === ddex ===
+  
+  ddex_web:
     image: audius/ddex:${TAG:-d5e07754095c01765ca3eb564fca710163a5f19d}
-    container_name: ddex
+    container_name: ddex_web
     restart: unless-stopped
     environment:
       - NODE_ENV=${NETWORK:-prod}
+      - DDEX_PORT=3000
     env_file:
       - ${OVERRIDE_PATH:-override.env}
     networks:
       - discovery-provider-network
+    ports:
+      - "3000:3000"
     profiles:
       - ddex
+
+  # === end ddex ===
 
   notifications:
     image: audius/discovery-provider-notifications:${TAG:-d5e07754095c01765ca3eb564fca710163a5f19d}


### PR DESCRIPTION
### Description
Staging DDEX's web service runs at the root basename on a standalone node, https://audius-ddex.staging.audius.co/.
This is done by setting `ROOT_HOST=ddex-web:3000` in `discovery-provider/override.env`: https://github.com/AudiusProject/audius-docker-compose/blob/stage/discovery-provider/Caddyfile#L41

Tested on the audius-stage-ddex node.
