### PR TITLE
Split up override tagging, remove unused 'set-tag' feature

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -670,60 +670,6 @@ def get_config(ctx, service):
 
 @cli.command()
 @click.option("--unset", is_flag=True)
-@click.option("-y", "--yes", is_flag=True)
-@click.argument("tag", required=False)
-@click.pass_context
-def set_tag(ctx, unset, yes, tag):
-    """Set the commit tag"""
-    if not unset and tag is None:
-        tag = click.prompt(click.style("Tag", bold=True))
-
-    if not unset:
-        try:
-            for commit in json.load(
-                urllib.request.urlopen(
-                    f"https://api.github.com/repos/AudiusProject/audius-protocol/commits?sha={tag}&per_page=10"
-                )
-            ):
-                short_message = commit["commit"]["message"].split("\n")[0]
-                click.echo(
-                    f"{click.style(commit['sha'][:8], bold=True, fg='yellow')}: "
-                    f"[{click.style(commit['commit']['author']['name'], bold=True, fg='blue')}] "
-                    f"{short_message}"
-                )
-        except (ConnectionError, urllib.error.HTTPError, json.JSONDecodeError):
-            click.secho("Failed to get commit messages", fg="red")
-
-        if not yes:
-            click.confirm(
-                click.style(
-                    "Do you want to continue? This will disable auto-upgrade if it's enabled.",
-                    bold=True,
-                ),
-                abort=True,
-                default=True,
-            )
-
-    if not unset:
-        click.echo(
-            "Disabling auto-upgrade (if enabled) in order to use a different tag..."
-        )
-        ctx.invoke(auto_upgrade, remove=True)
-
-    logging.info(f"audius-cli set-tag tag={tag!r}")
-    for service in SERVICES:
-        key = "TAG"
-        env_file = ctx.obj["manifests_path"] / service / ".env"
-        if unset:
-            logging.info(f"> audius-cli set-tag unset service={service!r}")
-            dotenv.unset_key(env_file, key)
-        else:
-            logging.info(f"> audius-cli set-tag service={service!r} tag={tag!r}")
-            dotenv.set_key(env_file, key, tag)
-
-
-@cli.command()
-@click.option("--unset", is_flag=True)
 @click.argument("service", required=True)
 @click.argument("path", type=click.Path(), required=False)
 @click.pass_context

--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       - creator-node-network
 
   mediorum:
-    image: audius/mediorum:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/mediorum:${OVERRIDE_AUDIUS_TAG_MEDIORUM:-09b058c9a36f712d47881b669c82e49f984f3d45}
     container_name: mediorum
     <<: *extra-hosts
     restart: unless-stopped
@@ -115,7 +115,7 @@ services:
           memory: 14G # 16G is required for all SPs, so we'll leave 2G for the OS, postgres, etc
 
   healthz:
-    image: audius/healthz:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/healthz:${OVERRIDE_AUDIUS_TAG_HEALTHZ:-09b058c9a36f712d47881b669c82e49f984f3d45}
     container_name: healthz
     restart: unless-stopped
     networks:
@@ -140,7 +140,7 @@ services:
       - dashboard-dist:/dashboard-dist
 
   dashboard:
-    image: audius/dashboard:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}-${NETWORK:-prod}
+    image: audius/dashboard:${OVERRIDE_AUDIUS_TAG_DASHBOARD:-09b058c9a36f712d47881b669c82e49f984f3d45}-${NETWORK:-prod}
     container_name: dashboard
     restart: unless-stopped
     networks:
@@ -149,7 +149,7 @@ services:
       - dashboard-dist:/app/dist
 
   uptime:
-    image: audius/uptime:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/uptime:${OVERRIDE_AUDIUS_TAG_UPTIME:-09b058c9a36f712d47881b669c82e49f984f3d45}
     container_name: uptime
     <<: *extra-hosts
     restart: unless-stopped

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -128,7 +128,7 @@ services:
       timeout: 5s
 
   relay:
-    image: audius/relay:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/relay:${OVERRIDE_AUDIUS_TAG_RELAY:-09b058c9a36f712d47881b669c82e49f984f3d45}
     container_name: relay
     <<: *extra-hosts
     restart: unless-stopped
@@ -151,7 +151,7 @@ services:
 
   backend:
     container_name: server
-    image: audius/discovery-provider:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/discovery-provider:${OVERRIDE_AUDIUS_TAG_DISCOVERY:-09b058c9a36f712d47881b669c82e49f984f3d45}
     <<: *extra-hosts
     restart: always
     mem_limit: "${SERVER_MEM_LIMIT:-16000000000}"
@@ -181,7 +181,7 @@ services:
 
   indexer:
     container_name: indexer
-    image: audius/discovery-provider:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/discovery-provider:${OVERRIDE_AUDIUS_TAG_DISCOVERY:-09b058c9a36f712d47881b669c82e49f984f3d45}
     <<: *extra-hosts
     restart: always
     mem_limit: 2.8g
@@ -223,7 +223,7 @@ services:
       - discovery-provider-network
 
   seed:
-    image: audius/discovery-provider:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/discovery-provider:${OVERRIDE_AUDIUS_TAG_DISCOVERY:-09b058c9a36f712d47881b669c82e49f984f3d45}
     command: bash /usr/share/seed.sh ${NETWORK:-prod}
     env_file:
       - ${NETWORK:-prod}.env
@@ -258,7 +258,7 @@ services:
       - discovery-provider-network
 
   comms:
-    image: audius/comms:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/comms:${OVERRIDE_AUDIUS_TAG_COMMS:-09b058c9a36f712d47881b669c82e49f984f3d45}
     container_name: comms
     command: comms discovery
     <<: *extra-hosts
@@ -277,7 +277,7 @@ services:
       driver: json-file
 
   es-indexer:
-    image: audius/es-indexer:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/es-indexer:${OVERRIDE_AUDIUS_TAG_ES_INDEXER:-09b058c9a36f712d47881b669c82e49f984f3d45}
     container_name: es-indexer
     restart: unless-stopped
     networks:
@@ -294,7 +294,7 @@ services:
       driver: json-file
 
   trpc:
-    image: audius/trpc:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/trpc:${OVERRIDE_AUDIUS_TAG_TRPC:-09b058c9a36f712d47881b669c82e49f984f3d45}
     container_name: trpc
     restart: unless-stopped
     networks:
@@ -358,7 +358,7 @@ services:
       driver: json-file
 
   healthz:
-    image: audius/healthz:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/healthz:${OVERRIDE_AUDIUS_TAG_HEALTHZ:-09b058c9a36f712d47881b669c82e49f984f3d45}
     container_name: healthz
     restart: unless-stopped
     networks:
@@ -383,7 +383,7 @@ services:
       - dashboard-dist:/dashboard-dist
 
   dashboard:
-    image: audius/dashboard:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}-${NETWORK:-prod}
+    image: audius/dashboard:${OVERRIDE_AUDIUS_TAG_DASHBOARD:-09b058c9a36f712d47881b669c82e49f984f3d45}-${NETWORK:-prod}
     container_name: dashboard
     restart: unless-stopped
     environment:
@@ -394,7 +394,7 @@ services:
       - dashboard-dist:/app/dist
 
   uptime:
-    image: audius/uptime:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/uptime:${OVERRIDE_AUDIUS_TAG_UPTIME:-09b058c9a36f712d47881b669c82e49f984f3d45}
     container_name: uptime
     <<: *extra-hosts
     restart: unless-stopped
@@ -409,7 +409,7 @@ services:
   # plugins
 
   ddex:
-    image: audius/ddex:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/ddex:${OVERRIDE_AUDIUS_TAG_DDEX:-09b058c9a36f712d47881b669c82e49f984f3d45}
     container_name: ddex
     restart: unless-stopped
     environment:
@@ -422,7 +422,7 @@ services:
       - ddex
 
   notifications:
-    image: audius/discovery-provider-notifications:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/discovery-provider-notifications:${OVERRIDE_AUDIUS_TAG_NOTIFICATIONS:-09b058c9a36f712d47881b669c82e49f984f3d45}
     container_name: notifications
     restart: unless-stopped
     networks:
@@ -443,7 +443,7 @@ services:
       - "6000:6000"
 
   sla-auditor:
-    image: audius/sla-auditor:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/sla-auditor:${OVERRIDE_AUDIUS_TAG_SLA_AUDITOR:-09b058c9a36f712d47881b669c82e49f984f3d45}
     container_name: sla-auditor
     restart: unless-stopped
     networks:

--- a/identity-service/docker-compose.yml
+++ b/identity-service/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - identity-service-network
 
   backend:
-    image: audius/identity-service:${TAG:-09b058c9a36f712d47881b669c82e49f984f3d45}
+    image: audius/identity-service:${OVERRIDE_AUDIUS_TAG_IDENTITY:-09b058c9a36f712d47881b669c82e49f984f3d45}
     container_name: server
     <<: *extra-hosts
     depends_on:


### PR DESCRIPTION
### Description

Since we are no longer automatically pushing docker images on development branches, the `audius-cli set-tag` feature doesn't make much sense anymore. Splitting up the ability to override various containers, however, is a more feasible approach to for development testing since the overridden images will need to be built locally first.