### PR TITLE
Recreate chain if unable to access internet

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -158,6 +158,19 @@ def prune():
         )
 
 
+def clear_clique_db():
+    print("Resetting chain")
+    run(
+        [
+            "docker",
+            "rm",
+            "--force",
+            "chain",
+        ],
+    )
+    clique_db_path = "/var/k8s/discovery-provider-chain/db/clique/"
+    run(["sudo", "rm", "-rf", clique_db_path])
+
 @click.group()
 @click.pass_context
 def cli(ctx):
@@ -870,34 +883,45 @@ def upgrade(ctx, branch):
 
         if service == "discovery-provider":
             ctx.invoke(launch_chain)
+            server_curl_res = run(
+                [
+                    "docker",
+                    "exec",
+                    "server",
+                    "curl",
+                    "-s",
+                    "--max-time",
+                    "10",
+                    "http://ipv4.icanhazip.com"
+                ],
+                stdout=subprocess.PIPE,  # This tells subprocess to capture standard output
+                stderr=subprocess.PIPE,  # This tells subprocess to capture standard error
+            text=True  # This makes sure the output is in text (string) format, not bytes
+            ).stdout.strip()
+            print("IP from server container: " + server_curl_res)
+
+            chain_curl_res = run(
+                [
+                    "docker",
+                    "exec",
+                    "chain",
+                    "curl",
+                    "-s",
+                    "--max-time",
+                    "10",
+                    "http://ipv4.icanhazip.com"
+                ],
+                stdout=subprocess.PIPE,  # This tells subprocess to capture standard output
+                stderr=subprocess.PIPE,  # This tells subprocess to capture standard error
+                text=True  # This makes sure the output is in text (string) format, not bytes
+            ).stdout.strip()
+            print("IP from chain container: " + chain_curl_res)
+            if server_curl_res and not chain_curl_res:
+                print("clear it")
+
         else:
             cleanup_disc_containers(ctx)
 
-        run(
-            [
-                "docker",
-                "exec",
-                "server",
-                "curl",
-                "-s",
-                "--max-time",
-                "10",
-                "http://ipv4.icanhazip.com"
-            ],
-        )
-
-        run(
-            [
-                "docker",
-                "exec",
-                "chain",
-                "curl",
-                "-s",
-                "--max-time",
-                "10",
-                "http://ipv4.icanhazip.com"
-            ],
-        )
 
 
     finally:
@@ -1195,18 +1219,7 @@ def launch_chain(ctx):
         prev_spec_data = json.load(open(spec_output))
         prev_network_id = prev_spec_data["params"]["networkID"]
         if prev_network_id != network_id:
-            print("Resetting chain")
-            run(
-                [
-                    "docker",
-                    "rm",
-                    "--force",
-                    "chain",
-                ],
-            )
-            clique_db_path = "/var/k8s/discovery-provider-chain/db/clique/"
-            run(["sudo", "rm", "-rf", clique_db_path])
-
+            clear_clique_db()
     spec_data["genesis"]["extraData"] = extra_data
     with open(spec_output, "w") as f:
         json.dump(spec_data, f, ensure_ascii=False, indent=2)

--- a/audius-cli
+++ b/audius-cli
@@ -876,6 +876,8 @@ def upgrade(ctx, branch):
                 ctx.obj["manifests_path"] / service,
                 *plugins,
                 "up",
+                "--force-recreate",
+                "vector",
                 "--remove-orphans",
                 "-d",
             ],

--- a/audius-cli
+++ b/audius-cli
@@ -172,7 +172,7 @@ def clear_clique_db():
     try:
         run(["sudo", "rm", "-rf", clique_db_path], timeout=60)
     except Exception as e:
-        print(f"An error occurred: {e}")
+        print(f"Error in removing clique db: {e}")
 
 @click.group()
 @click.pass_context
@@ -823,7 +823,6 @@ def pull_reset(ctx, branch):
 @click.pass_context
 def upgrade(ctx, branch):
     """Pulls from latest source and re-launches all running services"""
-    user_input = input("Enter your data: ")
     log_file = ctx.obj["manifests_path"] / "auto-upgrade.log"
     try:
         # clear the previous auto-upgrade logs

--- a/audius-cli
+++ b/audius-cli
@@ -919,7 +919,8 @@ def upgrade(ctx, branch):
             ).stdout.strip()
             print("IP from chain container: " + chain_curl_res)
             if server_curl_res and not chain_curl_res:
-                print("clear it")
+                clear_clique_db()
+                ctx.invoke(launch_chain)
 
         else:
             cleanup_disc_containers(ctx)

--- a/audius-cli
+++ b/audius-cli
@@ -159,17 +159,17 @@ def prune():
 
 
 def clear_clique_db():
-    print("Resetting chain")
-    run(
-        [
-            "docker",
-            "rm",
-            "--force",
-            "chain",
-        ],
-    )
-    clique_db_path = "/var/k8s/discovery-provider-chain/db/clique/"
     try:
+        print("Resetting chain")
+        run(
+            [
+                "docker",
+                "rm",
+                "--force",
+                "chain",
+            ],
+        )
+        clique_db_path = "/var/k8s/discovery-provider-chain/db/clique/"
         run(["sudo", "rm", "-rf", clique_db_path], timeout=60)
     except Exception as e:
         print(f"Error in removing clique db: {e}")

--- a/audius-cli
+++ b/audius-cli
@@ -169,7 +169,10 @@ def clear_clique_db():
         ],
     )
     clique_db_path = "/var/k8s/discovery-provider-chain/db/clique/"
-    run(["sudo", "rm", "-rf", clique_db_path])
+    try:
+        run(["sudo", "rm", "-rf", clique_db_path], timeout=60)
+    except Exception as e:
+        print(f"An error occurred: {e}")
 
 @click.group()
 @click.pass_context
@@ -820,6 +823,7 @@ def pull_reset(ctx, branch):
 @click.pass_context
 def upgrade(ctx, branch):
     """Pulls from latest source and re-launches all running services"""
+    user_input = input("Enter your data: ")
     log_file = ctx.obj["manifests_path"] / "auto-upgrade.log"
     try:
         # clear the previous auto-upgrade logs

--- a/audius-cli
+++ b/audius-cli
@@ -896,11 +896,11 @@ def upgrade(ctx, branch):
                     "10",
                     "http://ipv4.icanhazip.com"
                 ],
-                stdout=subprocess.PIPE,  # This tells subprocess to capture standard output
-                stderr=subprocess.PIPE,  # This tells subprocess to capture standard error
-            text=True  # This makes sure the output is in text (string) format, not bytes
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            text=True
             ).stdout.strip()
-            print("IP from server container: " + server_curl_res)
+            print("IP from server: " + server_curl_res)
 
             chain_curl_res = run(
                 [
@@ -913,12 +913,13 @@ def upgrade(ctx, branch):
                     "10",
                     "http://ipv4.icanhazip.com"
                 ],
-                stdout=subprocess.PIPE,  # This tells subprocess to capture standard output
-                stderr=subprocess.PIPE,  # This tells subprocess to capture standard error
-                text=True  # This makes sure the output is in text (string) format, not bytes
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, 
+                text=True
             ).stdout.strip()
-            print("IP from chain container: " + chain_curl_res)
+            print("IP from chain: " + chain_curl_res)
             if server_curl_res and not chain_curl_res:
+                # Clear and recreate chain if unable to access internet
                 clear_clique_db()
                 ctx.invoke(launch_chain)
 

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -348,7 +348,7 @@ services:
       - "30300:30300/udp"
       - "127.0.0.1:8545:8545"
     networks:
-      - discovery-provider-network
+      - no-internet
     profiles:
       - chain
     logging:
@@ -503,7 +503,10 @@ services:
 
 networks:
   discovery-provider-network:
-
+  no-internet:
+    driver: bridge
+    internal: true  # This prevents the containers from accessing the internet
+    
 volumes:
   esdata:
   caddy_data:

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -348,7 +348,7 @@ services:
       - "30300:30300/udp"
       - "127.0.0.1:8545:8545"
     networks:
-      - no-internet
+      - discovery-provider-network
     profiles:
       - chain
     logging:
@@ -503,10 +503,7 @@ services:
 
 networks:
   discovery-provider-network:
-  no-internet:
-    driver: bridge
-    internal: true  # This prevents the containers from accessing the internet
-    
+
 volumes:
   esdata:
   caddy_data:


### PR DESCRIPTION
### Description

Based on auto upgrade logs, some nodes have chain containers that lose internet connection which is strange because the server has access to the internet otherwise. I suspect clearing the DB and recreating the chain container might fix these cases. 

Also recreate vector container on every upgrade to pick up new auto upgrade logs. Even if compose tag is not updated yet.