### PR TITLE
[PROTO-1606] Continue postgres rollout to ~half of DNs

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -54,7 +54,7 @@ PG_UPGRADE_TO_VERSION = "audius_pg_upgrade_to_version"
 PG15_UPGRADE_STARTED = "audius_started_upgrade_to_pg15"
 PG15_UPGRADE_COMPLETE = "audius_completed_upgrade_to_pg15"
 PG15_UPGRADE_ROLLOUT_NUM = "audius_pg_upgrade_rollout_num"
-PG15_UPGRADE_ROLLOUT_MAX = 10
+PG15_UPGRADE_ROLLOUT_MAX = 30
 
 service_type = click.Choice(SERVICES)
 network_type = click.Choice(["prod", "stage", "dev"])


### PR DESCRIPTION
### Description
Rolls out the postgres upgrade to about half of Discovery Nodes. It's already rolled out to 1/6th successfully, including: culturestake3, culturestake9, culturestake14, culturestake17, and audius-nodes.com.

The only difference I see is that the db size is smaller. This is likely due to storage efficiency improvements in newer versions.