### PR TITLE
Add bootnodes for peer discovery

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -1031,6 +1031,8 @@ def launch_chain(ctx):
             "compose",
             "--env-file",
             get_override_path(ctx, "discovery-provider"),
+            "--env-file",
+            env,
             "--project-directory",
             ctx.obj["manifests_path"] / "discovery-provider",
             "up",

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -322,6 +322,7 @@ services:
       # Because the env_file is generated dynamically, default to blank string if not set
       # otherwise we will always see a warning.
       - NETHERMIND_KEYSTORECONFIG_TESTNODEKEY=${audius_delegate_private_key:-}
+      - NETHERMIND_DISCOVERYCONFIG_BOOTNODES=${audius_static_nodes:-}
     volumes:
       - ./chain/spec.json:/config/spec.json
       - ./chain/static-nodes.json:/nethermind/Data/static-nodes.json


### PR DESCRIPTION
### Description

Setting bootnodes here might help peer discovery. Tested on sandbox an stage.
https://ethereum.org/developers/docs/nodes-and-clients/bootnodes

