### PR TITLE
Remove processing health check + recreate problem nodes

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -890,22 +890,6 @@ def upgrade(ctx, branch):
 
         if service == "discovery-provider":
             ctx.invoke(launch_chain)
-            server_curl_res = run(
-                [
-                    "docker",
-                    "exec",
-                    "server",
-                    "curl",
-                    "-s",
-                    "--max-time",
-                    "10",
-                    "http://ipv4.icanhazip.com"
-                ],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            text=True
-            ).stdout.strip()
-            print("IP from server: " + server_curl_res)
 
             chain_curl_res = run(
                 [
@@ -923,7 +907,7 @@ def upgrade(ctx, branch):
                 text=True
             ).stdout.strip()
             print("IP from chain: " + chain_curl_res)
-            if server_curl_res and not chain_curl_res:
+            if chain_curl_res in ["209.161.4.44", "209.161.4.38", "3.235.40.101", "108.160.129.21"]:
                 # Clear and recreate chain if unable to access internet
                 clear_clique_db()
                 ctx.invoke(launch_chain)

--- a/discovery-provider/chain/config.cfg
+++ b/discovery-provider/chain/config.cfg
@@ -15,8 +15,7 @@
         "MaxActivePeers": 100
     },
     "HealthChecks": {
-        "Enabled": true,
-        "MaxIntervalWithoutProcessedBlock": 15,
+        "Enabled": true
     },
     "JsonRpc": {
         "Enabled": true,


### PR DESCRIPTION
### Description
There are 4 remaining unhealthy netherminde nodes. I suspect that this aggressive autohealing while a node syncs could have corrupted some data. I've seen cases where my sandbox disconnects with all peers because it has an old block that's empty while other nodes have the data. Re-syncing seems to resolve.

Turned on trace logging, verified my node would remove peers because of this discrepancy ^. Clearing clique db and re-syncing seems to have resolved.
 

Tested on sandbox.


