### PR TITLE
fix ddex network

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -486,7 +486,7 @@ services:
       timeout: 5s
       retries: 5
     networks:
-      - ddex-network
+      - discovery-provider-network
     profiles:
       - ddex
 


### PR DESCRIPTION
### Description

I believe this is causing issues on stage dn2 and potentially others

```
Do you want to continue? [y/N]: y
docker compose --project-directory /home/ubuntu/audius-docker-compose/discovery-provider pull
service "ddex-publisher" refers to undefined network ddex-network: invalid compose project
Traceback (most recent call last):
  File "/usr/local/bin/audius-cli", line 1103, in <module>
    cli(obj={})
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/bin/audius-cli", line 426, in launch
    run(
  File "/usr/local/bin/audius-cli", line 60, in run
    return subprocess.run(cmd, **kwargs)
  File "/usr/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['docker', 'compose', '--project-directory', PosixPath('/home/ubuntu/audius-docker-compose/discovery-provider'), 'pull']' returned non-zero exit status 15.
```