### PR TITLE
Fix chain env and only recreate once

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -906,11 +906,41 @@ def upgrade(ctx, branch):
                 stderr=subprocess.PIPE, 
                 text=True
             ).stdout.strip()
+
+            chain_created = run(
+                [
+                    "docker",
+                    "inspect",
+                    "chain",
+                    "-f",
+                    "\'{{ .Created }}\'",
+                    "chain"
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, 
+                text=True
+            ).stdout.strip()
+
             print("IP from chain: " + chain_curl_res)
-            if chain_curl_res in ["209.161.4.44", "209.161.4.38", "3.235.40.101", "108.160.129.21"]:
-                # Clear and recreate chain if unable to access internet
-                clear_clique_db()
-                ctx.invoke(launch_chain)
+            print("chain created: " + chain_created)
+
+            if chain_curl_res in ["209.161.4.44", "209.161.4.38", "3.235.40.101", "108.160.129.21"] and not chain_created.startswith("2024"):
+                # recreate problem containers once
+                run(
+                    [
+                        "docker",
+                        "compose",
+                        "--env-file",
+                        get_override_path(ctx, "discovery-provider"),
+                        "--project-directory",
+                        ctx.obj["manifests_path"] / "discovery-provider",
+                        "up",
+                        "-d",
+                        "--force-recreate",
+                        "chain",
+                    ],
+                )
+
 
     finally:
         lock(ctx, "docker")
@@ -1015,8 +1045,6 @@ def launch_chain(ctx):
             "compose",
             "--env-file",
             get_override_path(ctx, "discovery-provider"),
-            "--env-file",
-            env,
             "--project-directory",
             ctx.obj["manifests_path"] / "discovery-provider",
             "up",

--- a/audius-cli
+++ b/audius-cli
@@ -911,7 +911,6 @@ def upgrade(ctx, branch):
                 [
                     "docker",
                     "inspect",
-                    "chain",
                     "-f",
                     "\'{{ .Created }}\'",
                     "chain"
@@ -924,23 +923,10 @@ def upgrade(ctx, branch):
             print("IP from chain: " + chain_curl_res)
             print("chain created: " + chain_created)
 
-            if chain_curl_res in ["209.161.4.44", "209.161.4.38", "3.235.40.101", "108.160.129.21"] and not chain_created.startswith("2024"):
-                # recreate problem containers once
-                run(
-                    [
-                        "docker",
-                        "compose",
-                        "--env-file",
-                        get_override_path(ctx, "discovery-provider"),
-                        "--project-directory",
-                        ctx.obj["manifests_path"] / "discovery-provider",
-                        "up",
-                        "-d",
-                        "--force-recreate",
-                        "chain",
-                    ],
-                )
-
+            if chain_curl_res in ["209.161.4.44", "209.161.4.38", "3.235.40.101", "108.160.129.21"] and not chain_created.startswith("2024-02"):
+                # resync problem containers once
+                clear_clique_db()
+                ctx.invoke(launch_chain)
 
     finally:
         lock(ctx, "docker")


### PR DESCRIPTION
### Description

On stage, passing in the stage.env to the chain container seemed to have changed the node address for some reason. Not sure why but reverting that for now. 

Also ensuring chain containers are re-synced once