### PR TITLE
Add process check back

### DIFF
--- a/discovery-provider/chain/config.cfg
+++ b/discovery-provider/chain/config.cfg
@@ -15,7 +15,8 @@
         "MaxActivePeers": 100
     },
     "HealthChecks": {
-        "Enabled": true
+        "Enabled": true,
+        "MaxIntervalWithoutProcessedBlock": 15,
     },
     "JsonRpc": {
         "Enabled": true,


### PR DESCRIPTION
### Description

Removed in order to hopefully fix syncing issues, thinking constantly restarting while doing full sync could slow down / corrupt.

This is pretty important to keep for signer nodes though to prevent block production halts.