### PR TITLE
Update Discovery to latest

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       timeout: 5s
 
   relay:
-    image: audius/relay:${TAG:-c213244e3573b03956b73029a6881e6277bd5bb1}
+    image: audius/relay:${TAG:-23edd8144acc13da2b8d9000f2245e038b438874}
     container_name: relay
     <<: *extra-hosts
     restart: unless-stopped
@@ -126,7 +126,7 @@ services:
       - "6001:6001"
 
   openresty:
-    image: audius/discovery-provider-openresty:${TAG:-c213244e3573b03956b73029a6881e6277bd5bb1}
+    image: audius/discovery-provider-openresty:${TAG:-23edd8144acc13da2b8d9000f2245e038b438874}
     container_name: openresty
     <<: *extra-hosts
     restart: unless-stopped
@@ -139,7 +139,7 @@ services:
 
   backend:
     container_name: server
-    image: audius/discovery-provider:${TAG:-c213244e3573b03956b73029a6881e6277bd5bb1}
+    image: audius/discovery-provider:${TAG:-23edd8144acc13da2b8d9000f2245e038b438874}
     <<: *extra-hosts
     restart: always
     mem_limit: 8g
@@ -174,7 +174,7 @@ services:
 
   indexer:
     container_name: indexer
-    image: audius/discovery-provider:${TAG:-c213244e3573b03956b73029a6881e6277bd5bb1}
+    image: audius/discovery-provider:${TAG:-23edd8144acc13da2b8d9000f2245e038b438874}
     <<: *extra-hosts
     restart: always
     mem_limit: 8g
@@ -216,7 +216,7 @@ services:
       - discovery-provider-network
 
   seed:
-    image: audius/discovery-provider:${TAG:-c213244e3573b03956b73029a6881e6277bd5bb1}
+    image: audius/discovery-provider:${TAG:-23edd8144acc13da2b8d9000f2245e038b438874}
     command: bash /usr/share/seed.sh ${NETWORK:-prod}
     env_file:
       - ${NETWORK:-prod}.env
@@ -253,7 +253,7 @@ services:
       - /home/ubuntu/audius-docker-compose/auto-upgrade.log:/auto-upgrade.log
 
   comms:
-    image: audius/comms:${TAG:-c213244e3573b03956b73029a6881e6277bd5bb1}
+    image: audius/comms:${TAG:-23edd8144acc13da2b8d9000f2245e038b438874}
     container_name: comms
     command: comms discovery
     <<: *extra-hosts
@@ -272,7 +272,7 @@ services:
       driver: json-file
 
   es-indexer:
-    image: audius/es-indexer:${TAG:-c213244e3573b03956b73029a6881e6277bd5bb1}
+    image: audius/es-indexer:${TAG:-23edd8144acc13da2b8d9000f2245e038b438874}
     container_name: es-indexer
     restart: unless-stopped
     networks:
@@ -289,7 +289,7 @@ services:
       driver: json-file
 
   trpc:
-    image: audius/trpc:${TAG:-c213244e3573b03956b73029a6881e6277bd5bb1}
+    image: audius/trpc:${TAG:-23edd8144acc13da2b8d9000f2245e038b438874}
     container_name: trpc
     restart: unless-stopped
     networks:
@@ -354,7 +354,7 @@ services:
       driver: json-file
 
   healthz:
-    image: audius/healthz:${TAG:-c213244e3573b03956b73029a6881e6277bd5bb1}
+    image: audius/healthz:${TAG:-23edd8144acc13da2b8d9000f2245e038b438874}
     container_name: healthz
     restart: unless-stopped
     networks:
@@ -379,7 +379,7 @@ services:
       - dashboard-dist:/dashboard-dist
 
   dashboard:
-    image: audius/dashboard:${TAG:-c213244e3573b03956b73029a6881e6277bd5bb1}-${NETWORK:-prod}
+    image: audius/dashboard:${TAG:-23edd8144acc13da2b8d9000f2245e038b438874}-${NETWORK:-prod}
     container_name: dashboard
     restart: unless-stopped
     environment:
@@ -390,7 +390,7 @@ services:
       - dashboard-dist:/app/dist
 
   uptime:
-    image: audius/uptime:${TAG:-c213244e3573b03956b73029a6881e6277bd5bb1}
+    image: audius/uptime:${TAG:-23edd8144acc13da2b8d9000f2245e038b438874}
     container_name: uptime
     <<: *extra-hosts
     restart: unless-stopped
@@ -405,7 +405,7 @@ services:
   # plugins
 
   notifications:
-    image: audius/discovery-provider-notifications:${TAG:-c213244e3573b03956b73029a6881e6277bd5bb1}
+    image: audius/discovery-provider-notifications:${TAG:-23edd8144acc13da2b8d9000f2245e038b438874}
     container_name: notifications
     restart: unless-stopped
     networks:
@@ -426,7 +426,7 @@ services:
       - "6000:6000"
 
   sla-auditor:
-    image: audius/sla-auditor:${TAG:-c213244e3573b03956b73029a6881e6277bd5bb1}
+    image: audius/sla-auditor:${TAG:-23edd8144acc13da2b8d9000f2245e038b438874}
     container_name: sla-auditor
     restart: unless-stopped
     networks:


### PR DESCRIPTION
### Description

Updates Discovery because a failed image is blocking the latest changes from being automatically committed. I tested on a stage node to double-check that it can pull each image with this new tag and run successfully.