### PR TITLE
Update ddex health checks

### DIFF
--- a/ddex/docker-compose.yml
+++ b/ddex/docker-compose.yml
@@ -52,6 +52,8 @@ services:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}
     entrypoint: ./ingester --service crawler
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep ./ingester || exit 1"]
     networks:
       - ddex-network
 
@@ -67,6 +69,8 @@ services:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}
     entrypoint: ./ingester --service indexer
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep ./ingester || exit 1"]
     networks:
       - ddex-network
 
@@ -82,6 +86,8 @@ services:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}
     entrypoint: ./ingester --service parser
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep ./ingester || exit 1"]
     networks:
       - ddex-network
 
@@ -101,10 +107,7 @@ services:
     ports:
       - "9001:9001"
     healthcheck:
-      test: curl --fail -I http://localhost:9001/api/health_check || exit 1
-      interval: 15s
-      timeout: 5s
-      retries: 5
+      test: ["CMD-SHELL", "pgrep node || exit 1"]
     networks:
       - ddex-network
 


### PR DESCRIPTION
The DDEX publisher was reporting unhealthy because I removed its Express server, so this PR changes its health check to use `pgrep`. Also adds health checks to the other DDEX services. Tested on stage.

<img width="2160" alt="docker ps -a screenshot showing healthy" src="https://github.com/AudiusProject/audius-docker-compose/assets/4657956/d530abe0-f6d8-4258-910e-cfd32c7ea545">
