### PR TITLE
Launch chain before launching the stack

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -473,6 +473,9 @@ def launch(ctx, service, seed, chain, yes):
 
     plugins = get_registered_plugins(ctx, service)
 
+    if service == "discovery-provider":
+        ctx.invoke(launch_chain)
+
     run(
         [
             "docker",
@@ -486,9 +489,6 @@ def launch(ctx, service, seed, chain, yes):
         ],
         check=True,
     )
-
-    if service == "discovery-provider":
-        ctx.invoke(launch_chain)
 
     prune()
 


### PR DESCRIPTION
### Description

The server container depends on the chain but we can't codify this dependency because we want the chain on a different docker compose profile so that it won't get restarted during auto-upgrades.

Launching the chain before launching discovery provider helps with the race condition where [discprov server caches it's web3 endpoint before the chain is ready](https://github.com/AudiusProject/audius-protocol/blob/main/packages/discovery-provider/src/utils/web3_provider.py#L32).

### How was this tested?

Successfully deployed this change on stage discovery 3