### PR TITLE
Lower prune threshold to save more disk space

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -153,7 +153,7 @@ def prune():
         )
     else:
         run(
-            ["docker", "system", "prune", "--all", "--force", "--filter", "until=336h"],
+            ["docker", "system", "prune", "--all", "--force", "--filter", "until=48h"],
         )
 
 


### PR DESCRIPTION
### Description

We don't need the threshold to be 15 days, this will fill up disk space too quickly. 48hrs should be more than enough, especially since pruning won't affect containers currently in use.