### PR TITLE
Safe audius_static_nodes parsing

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -1035,7 +1035,7 @@ def launch_chain(ctx):
         f.write("\n")
 
     # Get peers from env
-    peers_str = env_data.get("audius_static_nodes")
+    peers_str = env_data.get("audius_static_nodes") or ""
     peers = peers_str.split(",")
 
     static_peers_file = (

--- a/discovery-provider/dev.env
+++ b/discovery-provider/dev.env
@@ -42,3 +42,6 @@ audius_web3_eth_provider_url="http://eth-ganache.devnet.audius-d"
 audius_web3_host="http://acdc-ganache.devnet.audius-d"
 audius_web3_localhost="http://acdc-ganache.devnet.audius-d"
 audius_web3_port=443
+
+audius_static_nodes=""
+audius_genesis_signers=""


### PR DESCRIPTION
### Description

discovery failing to boot up in envs other than stage / prod

```
File "/root/audius-docker-compose/./audius-cli", line 1039, in launch_chain
!    peers = peers_str.split(",")
            ^^^^^^^^^^^^^^^
;AttributeError: 'NoneType' object has no attribute 'split'
```

See 
pre fix: https://app.circleci.com/pipelines/github/AudiusProject/audius-d/760 
post fix: https://app.circleci.com/pipelines/github/AudiusProject/audius-d/777/workflows/4f8273c4-4d47-4bf3-ba7b-99fb8c7384fb/jobs/2070