### PR TITLE
Reseed exposed postgres (discovery + content)

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -834,7 +834,7 @@ def pull_reset(ctx, branch):
 
 
 def get_db_size(database_name):
-    cmd = f"""docker exec postgres psql audius_discovery postgres -tAc "select pg_database_size('{database_name}')""""
+    cmd = f"docker exec postgres psql audius_discovery postgres -tAc \"select pg_database_size('{database_name}')\""
     try:
         output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, universal_newlines=True)
         db_size_bytes = int(output.strip())

--- a/audius-cli
+++ b/audius-cli
@@ -833,6 +833,19 @@ def pull_reset(ctx, branch):
         sys.exit(1)
 
 
+def get_db_size(database_name):
+    cmd = f"""docker exec postgres psql audius_discovery postgres -tAc "select pg_database_size('{database_name}')"""
+    try:
+        output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, universal_newlines=True)
+        db_size_bytes = int(output.strip())
+        db_size_mb = db_size_bytes / (1024 * 1024)
+        print(f"Got database size {db_size_mb}mb for {database_name}")
+        return db_size_mb
+    except subprocess.CalledProcessError as e:
+        print(f"Error getting database size: {e}")
+        raise e
+
+
 @cli.command()
 @click.argument("branch", required=False)
 @click.pass_context
@@ -881,11 +894,12 @@ def upgrade(ctx, branch):
         )
 
         if service == "discovery-provider":
+            db_size = get_db_size("audius_discovery")
             reseeded = dotenv.get_key(disc_override_env, RESEEDED_EXPOSED_POSTGRES)
-            if reseeded != "true":
-              ctx.invoke(launch, service=service, seed=True)
-              dotenv.set_key(disc_override_env, RESEEDED_EXPOSED_POSTGRES, "true")
-              return
+            if reseeded != "true" and db_size < 1024:
+                ctx.invoke(launch, service=service, seed=True)
+                dotenv.set_key(disc_override_env, RESEEDED_EXPOSED_POSTGRES, "true")
+                return
 
         plugins = get_registered_plugins(ctx, service)
 

--- a/audius-cli
+++ b/audius-cli
@@ -902,9 +902,12 @@ def upgrade(ctx, branch):
                 return
 
         if service == "creator-node":
-            # If create database fails, continue and swallow error
-            cmd = 'docker exec postgres psql -U postgres -c "CREATE DATABASE audius_creator_node;"'
-            run(cmd, shell=True)
+            try:
+                # If create database fails, continue and swallow error
+                cmd = 'docker exec postgres psql -U postgres -c "CREATE DATABASE audius_creator_node;"'
+                run(cmd, shell=True)
+            except Exception as e:
+                print(f"Error creating creator node db {e}")
 
         plugins = get_registered_plugins(ctx, service)
 

--- a/audius-cli
+++ b/audius-cli
@@ -53,6 +53,8 @@ REGISTERED_PLUGINS = "REGISTERED_PLUGINS"
 EXTRA_VANITY = "0x22466c6578692069732061207468696e6722202d204166726900000000000000"
 EXTRA_SEAL = "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 
+RESEEDED_EXPOSED_POSTGRES = "reseeded_exposed_postgres"
+
 service_type = click.Choice(SERVICES)
 network_type = click.Choice(["prod", "stage", "dev"])
 container_type = click.Choice(["backend", "cache", "db"])
@@ -877,6 +879,13 @@ def upgrade(ctx, branch):
                 "pull",
             ],
         )
+
+        if service == "discovery-provider":
+            reseeded = dotenv.get_key(disc_override_env, RESEEDED_EXPOSED_POSTGRES)
+            if reseeded != "true":
+              ctx.invoke(launch, service=service, seed=True)
+              dotenv.set_key(disc_override_env, RESEEDED_EXPOSED_POSTGRES, "true")
+              return
 
         plugins = get_registered_plugins(ctx, service)
 

--- a/audius-cli
+++ b/audius-cli
@@ -901,6 +901,11 @@ def upgrade(ctx, branch):
                 dotenv.set_key(disc_override_env, RESEEDED_EXPOSED_POSTGRES, "true")
                 return
 
+        if service == "creator-node":
+            # If create database fails, continue and swallow error
+            cmd = 'docker exec postgres psql -U postgres -c "CREATE DATABASE audius_creator_node;"'
+            run(cmd, shell=True)
+
         plugins = get_registered_plugins(ctx, service)
 
         run(

--- a/audius-cli
+++ b/audius-cli
@@ -834,7 +834,7 @@ def pull_reset(ctx, branch):
 
 
 def get_db_size(database_name):
-    cmd = f"""docker exec postgres psql audius_discovery postgres -tAc "select pg_database_size('{database_name}')"""
+    cmd = f"""docker exec postgres psql audius_discovery postgres -tAc "select pg_database_size('{database_name}')""""
     try:
         output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, universal_newlines=True)
         db_size_bytes = int(output.strip())

--- a/audius-cli
+++ b/audius-cli
@@ -839,7 +839,7 @@ def get_db_size(database_name):
         output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, universal_newlines=True)
         db_size_bytes = int(output.strip())
         db_size_mb = db_size_bytes / (1024 * 1024)
-        print(f"Got database size {db_size_mb}mb for {database_name}")
+        print(f"Got database size {db_size_mb}MB for {database_name}")
         return db_size_mb
     except subprocess.CalledProcessError as e:
         print(f"Error getting database size: {e}")
@@ -897,7 +897,7 @@ def upgrade(ctx, branch):
             db_size = get_db_size("audius_discovery")
             reseeded = dotenv.get_key(disc_override_env, RESEEDED_EXPOSED_POSTGRES)
             if reseeded != "true" and db_size < 1024:
-                ctx.invoke(launch, service=service, seed=True)
+                ctx.invoke(launch, service=service, seed=True, yes=True)
                 dotenv.set_key(disc_override_env, RESEEDED_EXPOSED_POSTGRES, "true")
                 return
 


### PR DESCRIPTION
Re-seeds discovery once unless `reseeded_exposed_postgres` env var is set to `true`.