### PR TITLE
Remove all unnecessary published ports

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -28,8 +28,6 @@ services:
       test: ['CMD', 'pg_isready', '-U', 'postgres']
       interval: 10s
       timeout: 5s
-    ports:
-      - '127.0.0.1:5432:5432'
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -87,9 +85,6 @@ services:
     restart: unless-stopped
     networks:
       - creator-node-network
-    ports:
-      - "${MEDIORUM_PORT:-4000}:1991"
-      - 127.0.0.1:6060:6060
     env_file:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -348,7 +348,6 @@ services:
     ports:
       - "30300:30300"
       - "30300:30300/udp"
-      - "127.0.0.1:8545:8545"
     networks:
       - discovery-provider-network
     profiles:

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -28,8 +28,6 @@ services:
       test: ['CMD', 'pg_isready', '-U', 'postgres']
       interval: 10s
       timeout: 5s
-    ports:
-      - '${EXPOSE_POSTGRES:-127.0.0.1:5432}:5432'
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -90,8 +88,6 @@ services:
         hard: -1
     volumes:
       - esdata:/usr/share/elasticsearch/data
-    ports:
-      - ${EXPOSE_ELASTICSEARCH:-127.0.0.1:39200}:9200
     networks:
       - discovery-provider-network
     healthcheck:
@@ -122,8 +118,6 @@ services:
         mode: non-blocking
         max-buffer-size: 100m
       driver: json-file
-    ports:
-      - "6001:6001"
 
   solana-relay:
     image: audius/solana-relay:${TAG:-d48038db8f27de50dee7613d5c541cb2759be4ea}
@@ -144,8 +138,6 @@ services:
         mode: non-blocking
         max-buffer-size: 100m
       driver: json-file
-    ports:
-      - "6002:6002"
 
   openresty:
     image: audius/discovery-provider-openresty:${TAG:-d48038db8f27de50dee7613d5c541cb2759be4ea}
@@ -156,8 +148,6 @@ services:
       - ${OVERRIDE_PATH:-override.env}
     networks:
       - discovery-provider-network
-    ports:
-      - "5000:5000"
 
   backend:
     container_name: server
@@ -181,8 +171,6 @@ services:
         condition: service_healthy
     labels:
       autoheal: "true"
-    ports:
-      - "3000:3000"
     env_file:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}
@@ -326,8 +314,6 @@ services:
         mode: non-blocking
         max-buffer-size: 100m
       driver: json-file
-    ports:
-      - "2022:2022"
 
   chain:
     image: audius/nethermind:1.14.3
@@ -444,8 +430,6 @@ services:
       driver: json-file
     profiles:
       - notifications
-    ports:
-      - "6000:6000"
 
   sla-auditor:
     image: audius/sla-auditor:${TAG:-d48038db8f27de50dee7613d5c541cb2759be4ea}
@@ -481,8 +465,6 @@ services:
       MB_DB_HOST: postgres
     networks:
       - discovery-provider-network
-    ports:
-      - "3000:3000"
     profiles:
       - metabase
     healthcheck:


### PR DESCRIPTION
### Description

These ports are used by the internal services. Publishing them via the `ports:` docker compose directive exposes them on the host level. This is unnecessary and presents potential security risks for nodes operating without a firewall.

Tested on stage dn5 and stage creator 12.