### PR TITLE
Increase healthcheck timeout on elasticsearch

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -98,6 +98,7 @@ services:
         ]
       interval: 10s
       timeout: 5s
+      start_period: 40s
 
   relay:
     image: audius/relay:${TAG:-a7e4c142fde81e81c224966730a147e073aafa4a}


### PR DESCRIPTION
### Description

Lately when trying to launch discovery provider it keeps prematurely failing because elasticsearch is unhealthy even though elasticsearch later becomes healthy on its own.
