### PR TITLE
Revert "Increase healthcheck timeout on elasticsearch"

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -98,7 +98,6 @@ services:
         ]
       interval: 10s
       timeout: 5s
-      start_period: 40s
 
   relay:
     image: audius/relay:${TAG:-28f1150f90acc528cd1cde3d02b819e4d4de6ddb}


### PR DESCRIPTION
Reverts AudiusProject/audius-docker-compose#495

this is causing merge conflicts on release and we'll need to hotfix it today, reverting now so we can do that and fix foundation + stage after the fact