### PR TITLE
Make DDEX work with protocol changes

### DIFF
--- a/ddex/dev.env
+++ b/ddex/dev.env
@@ -10,5 +10,5 @@ DDEX_ADMIN_ALLOWLIST=
 SESSION_SECRET='CHANGE ME TO ANYTHING RANDOM'
 AWS_REGION='us-west-2'
 AWS_BUCKET_RAW='ddex-dev-audius-raw'
-AWS_BUCKET_INDEXED='ddex-dev-audius-indexed'
+AWS_BUCKET_CRAWLED='ddex-dev-audius-crawled'
 DDEX_CHOREOGRAPHY='ERNReleaseByRelease'

--- a/ddex/docker-compose.yml
+++ b/ddex/docker-compose.yml
@@ -57,23 +57,6 @@ services:
     networks:
       - ddex-network
 
-  ddex-indexer:
-    image: audius/ddex-ingester:${TAG:-f1472a7c1fdfc9cc29d0e3f203ef134d2cab7185}
-    container_name: ddex-indexer
-    depends_on:
-      ddex-mongo-init:
-        condition: service_completed_successfully
-    environment:
-      - DDEX_MONGODB_URL=mongodb://mongo:mongo@ddex-mongo:27017/ddex?authSource=admin&replicaSet=rs0
-    env_file:
-      - ${NETWORK:-prod}.env
-      - ${OVERRIDE_PATH:-override.env}
-    entrypoint: ./ingester --service indexer
-    healthcheck:
-      test: ["CMD-SHELL", "pgrep ./ingester || exit 1"]
-    networks:
-      - ddex-network
-
   ddex-parser:
     image: audius/ddex-ingester:${TAG:-f1472a7c1fdfc9cc29d0e3f203ef134d2cab7185}
     container_name: ddex-parser

--- a/ddex/prod.env
+++ b/ddex/prod.env
@@ -9,7 +9,7 @@ DDEX_ADMIN_ALLOWLIST=
 SESSION_SECRET='CHANGE ME TO ANYTHING RANDOM'
 AWS_REGION='us-west-2'
 AWS_BUCKET_RAW='ddex-prod-audius-raw'
-AWS_BUCKET_INDEXED='ddex-prod-audius-indexed'
+AWS_BUCKET_CRAWLED='ddex-prod-audius-crawled'
 DDEX_URL='audius-ddex.audius.co'
 DDEX_CHOREOGRAPHY='ERNReleaseByRelease'
 

--- a/ddex/stage.env
+++ b/ddex/stage.env
@@ -9,7 +9,7 @@ DDEX_ADMIN_ALLOWLIST=
 SESSION_SECRET='CHANGE ME TO ANYTHING RANDOM'
 AWS_REGION='us-west-2'
 AWS_BUCKET_RAW='ddex-staging-audius-raw'
-AWS_BUCKET_INDEXED='ddex-staging-audius-indexed'
+AWS_BUCKET_CRAWLED='ddex-staging-audius-crawled'
 DDEX_URL='audius-ddex.staging.audius.co'
 DDEX_CHOREOGRAPHY='ERNReleaseByRelease'
 


### PR DESCRIPTION
### Description

Changes DDEX to be compatible with recent changes in audius-protocol, including removing the "indexer" service and renaming the "-indexed" bucket to "-crawled."

DDEX now auto-upgrades on staging again. I also updated the buckets in S3 (deleted "indexed," created "crawled," and updated IAM policies).