### PR TITLE
Add healthcheck start period in a way that doesn't cause merge conflicts

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -97,6 +97,7 @@ services:
           "curl --silent --fail elasticsearch:9200/_cluster/health || exit 1"
         ]
       interval: 10s
+      start_period: 40s
       timeout: 5s
 
   relay:


### PR DESCRIPTION
### Description

Until we fix the divergence between stage, foundation, and main branches, this change has to be added in a way that doesn't touch the invisible forbidden void of merge conflict zone.