### PR TITLE
Keep tag when auto-upgrading

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -723,22 +723,6 @@ def set_tag(ctx, unset, yes, tag):
         except (ConnectionError, urllib.error.HTTPError, json.JSONDecodeError):
             click.secho("Failed to get commit messages", fg="red")
 
-        if not yes:
-            click.confirm(
-                click.style(
-                    "Do you want to continue? This will disable auto-upgrade if it's enabled.",
-                    bold=True,
-                ),
-                abort=True,
-                default=True,
-            )
-
-    if not unset:
-        click.echo(
-            "Disabling auto-upgrade (if enabled) in order to use a different tag..."
-        )
-        ctx.invoke(auto_upgrade, remove=True)
-
     logging.info(f"audius-cli set-tag tag={tag!r}")
     for service in SERVICES:
         key = "TAG"
@@ -980,7 +964,6 @@ def auto_upgrade(ctx, remove, cron_expression):
             job = cron.new(
                 (
                     f"date >> {log_file};"
-                    f"/usr/local/bin/audius-cli set-tag --unset --yes >> {log_file} 2>&1;"
                     f"/usr/local/bin/audius-cli upgrade >> {log_file} 2>&1;"
                 ),
                 "audius-cli auto-upgrade",


### PR DESCRIPTION
### Description

The set-tag feature will become an implementation detail as part of audius-d versioning. Auto-upgrade should remain enabled so that images can stay on the latest version of containers with a given tag. Setting the tag to a pinned version will be the de facto way of disabling auto-upgrade.

Tested by running local audius-d node on this branch with `set-tag` used by audius-ctl (see https://github.com/AudiusProject/audius-d/pull/100)