### PR TITLE
Add auto-seed flag to audius-cli

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -48,6 +48,7 @@ SERVICES = (
 )
 
 REGISTERED_PLUGINS = "REGISTERED_PLUGINS"
+DB_URL = "audius_db_url"
 
 # Used for updating chainspec
 EXTRA_VANITY = "0x22466c6578692069732061207468696e6722202d204166726900000000000000"
@@ -392,11 +393,16 @@ class MultiProvider(BaseProvider):
 
 @cli.command()
 @click.option("-y", "--yes", is_flag=True)
-@click.option("--seed", is_flag=True)
+@click.option("--seed", is_flag=True, help="Seed the discovery-provider database")
+@click.option(
+    "--auto-seed", 
+    is_flag=True, 
+    help="Seed the discovery-provider database if it's empty (e.g. for new nodes)",
+)
 @click.option("--chain", is_flag=True)
 @click.argument("service", type=service_type)
 @click.pass_context
-def launch(ctx, service, seed, chain, yes):
+def launch(ctx, service, seed, auto_seed, chain, yes):
     """Launch the service"""
     set_automatic_env(ctx)
 
@@ -441,7 +447,7 @@ def launch(ctx, service, seed, chain, yes):
         check=True,
     )
 
-    if seed and service == "discovery-provider":
+    if service == "discovery-provider" and (seed or auto_seed):
         # make sure services that use postgres are not running
         run(
             [
@@ -468,6 +474,10 @@ def launch(ctx, service, seed, chain, yes):
                 ctx.obj["manifests_path"] / "discovery-provider",
                 "run",
                 "seed",
+                "bash",
+                "/usr/share/seed.sh",
+                get_network(ctx, "discovery-provider"),
+                "true" if auto_seed else "false",
             ],
         )
 

--- a/discovery-provider/seed.sh
+++ b/discovery-provider/seed.sh
@@ -2,6 +2,24 @@
 set -e
 
 NETWORK=$1
+AUTOSEED=$2
+
+MIN_DB_SIZE="2147483648"  # 2GB
+
+function should_auto_seed() {
+  db_size="$(psql "$audius_db_url" -t -c "SELECT pg_database_size(current_database());")"
+  echo Current DB size detected as "$db_size"
+  if [ -n "$db_size" ] && [[ "$db_size" -gt "0" ]] && [[ "$db_size" -lt "$MIN_DB_SIZE" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+if [[ "$AUTOSEED" = "true" ]] && ! should_auto_seed; then
+  echo "(auto-seed) skipping seeding as database appears to already be populated."
+  exit 0
+fi
 
 if [[ "$NETWORK" == "prod" ]]; then
   echo "Downloading $NETWORK database..."
@@ -13,6 +31,8 @@ elif [[ "$NETWORK" == "stage" ]]; then
   curl https://audius-pgdump.s3-us-west-2.amazonaws.com/discProvStaging.dump -O
   echo "Restoring $NETWORK database to $audius_db_url..."
   pg_restore -d $audius_db_url --username postgres --no-privileges --clean --if-exists --verbose -j 8 discProvStaging.dump
+elif [[ "$NETWORK" == "dev" ]]; then
+  echo "Skipping seeding for dev network"
 else
   echo "Invalid network: $NETWORK"
   exit 1


### PR DESCRIPTION
### Description

This feature allows audius-d to automatically check if seeding is necessary when nodes are launched. This avoids having the extra seeding step during new node onboarding. The script simply checks if the database is below 2GB (stage db is ~25GB, prod is ~100GB, a fresh new database is only around 13MB).

Tested on stage dn5 (local database) and stage dn4 (remote database) - in both cases auto-seeding was correctly skipped because the database is already populated. Regular seeding should not be impacted.