### PR TITLE
Remove empty chain spec directories

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -1017,7 +1017,11 @@ def launch_chain(ctx):
     prev_network_id = None
     network_id = spec_data["params"]["networkID"]
 
-    if os.path.isfile(spec_output):
+    if os.path.isdir(spec_output):
+        # An empty dir can be created when chain container is recreated by docker
+        # due to how docker handles volume mounts
+        os.rmdir(spec_output)
+    elif os.path.isfile(spec_output):
         prev_spec_data = json.load(open(spec_output))
         prev_network_id = prev_spec_data["params"]["networkID"]
         if prev_network_id != network_id:
@@ -1034,6 +1038,10 @@ def launch_chain(ctx):
     static_peers_file = (
         ctx.obj["manifests_path"] / "discovery-provider" / "chain" / "static-nodes.json"
     )
+    if os.path.isdir(static_peers_file):
+        # An empty dir can be created when chain container is recreated by docker
+        # due to how docker handles volume mounts
+        os.rmdir(static_peers_file)
     with open(static_peers_file, "w") as f:
         json.dump(peers, f, ensure_ascii=False, indent=2)
         f.write("\n")


### PR DESCRIPTION
### Description

If the audius-d wrapper container is shut down uncleanly, the services inside will auto-restart when it is spun up again. The internal containers will create their file volume mounts as empty directories. This will ensure those files are deleted if they are directories to avoid errors.

Tested with audius-d locally.