### PR TITLE
Fix health check

### DIFF
--- a/utilities/discovery-provider/healthChecks.js
+++ b/utilities/discovery-provider/healthChecks.js
@@ -92,7 +92,7 @@ async function acdcPeerCheck() {
   }
   const discoveryResp = await axios(discoveryRequestConfig)
   assert.deepStrictEqual(discoveryResp.status, 200)
-  assert.deepStrictEqual(discoveryResp.data, true)
+  assert.deepStrictEqual(discoveryResp.data.split('\n')?.[1], 'true')
   console.log('✓ acdc peering check')
 }
 


### PR DESCRIPTION
### Description

Fix issue in checks on the /chain/peer endpoint

```
discoveryProviderEndpoint=https://discoveryprovider.audius.co npm run discovery:health
```

```
> sp-actions@1.0.0 discovery:health
> node discovery-provider/healthChecks.js

✓ Health check passed successfully
✓ IP forwarding check passed successfully
✓ websocket OK: wss://discoveryprovider.audius.co/comms/debug/ws
✓ acdc peering check
All checks passed!
```
