### PR TITLE
[PROTO-1841] Add memory limit to chain container

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -353,6 +353,7 @@ services:
       - "30300:30300/udp"
     networks:
       - discovery-provider-network
+    mem_limit: ${CHAIN_MEM_LIMIT:-2500000000}
     profiles:
       - chain
     logging:


### PR DESCRIPTION
### Description

Nodes regularly lock up from running out of memory while the chain is syncing. This may help prevent that from happening.

This was tested on dn1 tikilabs node.