### PR TITLE
turn off discovery listens in prod

### DIFF
--- a/creator-node/prod.env
+++ b/creator-node/prod.env
@@ -29,7 +29,7 @@ ethTokenAddress=0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998
 MEDIORUM_ENV=prod
 identityService=https://identityservice.audius.co
 logLevel=info
-discoveryListensEndpoints=https://discoveryprovider.audius.co
+# discoveryListensEndpoints=https://discoveryprovider.audius.co
 
 # logging
 audius_axiom_dataset=content


### PR DESCRIPTION
### Description
The errors in prod aren't quite the same as stage. Turning this off and just turning on for foundation through override until bugs ironed out.