### PR TITLE
[PROTO-1875] Mount auto-upgrade logs to vector container in audius-d compatible way

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -80,6 +80,8 @@ services:
       - ${OVERRIDE_PATH:-override.env}
     networks:
       - creator-node-network
+    volumes:
+      - ../auto-upgrade.log:/auto-upgrade.log
 
   mediorum:
     image: audius/mediorum:${TAG:-2969125129e90230cd7e89b0d2f0bce3aa1b6e0d}

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -263,7 +263,7 @@ services:
     networks:
       - discovery-provider-network
     volumes:
-      - /home/ubuntu/audius-docker-compose/auto-upgrade.log:/auto-upgrade.log
+      - ../auto-upgrade.log:/auto-upgrade.log
 
   comms:
     image: audius/comms:${TAG:-2969125129e90230cd7e89b0d2f0bce3aa1b6e0d}


### PR DESCRIPTION
### Description

We're missing these logs for content nodes and audius-d migrated nodes.