### PR TITLE
Add setuptools as explicit dependency (because of web3)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ psutil==5.9.0
 python-dotenv==0.20.0
 python-crontab==2.6.0
 web3==6.6.1
+setuptools==72.1.0


### PR DESCRIPTION
### Description

web3 depends on the pgk_resources module from setuptools, but fails to include this in its dependencies.