### PR TITLE
Add /console on content nodes

### DIFF
--- a/creator-node/Caddyfile
+++ b/creator-node/Caddyfile
@@ -13,10 +13,12 @@
 
   reverse_proxy mediorum:1991
   reverse_proxy /healthz* healthz
+  reverse_proxy /console* core:26659
+
   route /dashboard* {
       redir /dashboard /dashboard/ 308
       uri strip_prefix /dashboard
       root * /dashboard-dist
       file_server
-  }
+  }     
 }


### PR DESCRIPTION
### Description

Update Caddy to include core console route

**TEST**

Tested on both:
- https://creatornode6.staging.audius.co/console (core plugin is running, expected to work)
- https://creatornode5.staging.audius.co/console (core plugin not running, expected NOT to work)
