### PR TITLE
Remove unused content node redis

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -71,14 +71,6 @@ services:
     networks:
       - creator-node-network
 
-  cache:
-    container_name: redis
-    extends:
-      file: ../common-services.yml
-      service: base-redis
-    networks:
-      - creator-node-network
-
   autoheal:
     image: willfarrell/autoheal
     container_name: autoheal


### PR DESCRIPTION
**TEST** 

grepped all code for mentions of `cache, redis, redisHost, 6379` none found in `mediorum`.

tested on prod box and working nominally.
