### PR TITLE
Pin uptime container to 'current' tag

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -151,7 +151,7 @@ services:
       - caddy_config:/config
 
   uptime:
-    image: audius/uptime:${TAG:-7e83b42e9fefad5676814e24d07024a03e143e3a}
+    image: audius/uptime:current
     container_name: uptime
     <<: *extra-hosts
     restart: unless-stopped

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -407,7 +407,7 @@ services:
       - caddy_config:/config
 
   uptime:
-    image: audius/uptime:${TAG:-7e83b42e9fefad5676814e24d07024a03e143e3a}
+    image: audius/uptime:current
     container_name: uptime
     <<: *extra-hosts
     restart: unless-stopped


### PR DESCRIPTION
### Description

This container almost never changes and will soon be absorbed into core.

