### PR TITLE
Default to 'current' tag when unset

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -13,7 +13,7 @@ x-extra-hosts: &extra-hosts
 services:
   core:
     container_name: core
-    image: audius/core:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/core:${TAG:-current}
     restart: unless-stopped
     ports:
       - "26656:26656" # CometBFT P2P Server
@@ -105,7 +105,7 @@ services:
       - ../auto-upgrade.log:/auto-upgrade.log
 
   mediorum:
-    image: audius/mediorum:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/mediorum:${TAG:-current}
     container_name: mediorum
     <<: *extra-hosts
     restart: unless-stopped

--- a/ddex/docker-compose.yml
+++ b/ddex/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - caddy_config:/config
 
   ddex:
-    image: audius/ddex-processor:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/ddex-processor:${TAG:-current}
     container_name: ddex
     restart: unless-stopped
     environment:

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -13,7 +13,7 @@ x-extra-hosts: &extra-hosts
 services:
   core:
     container_name: core
-    image: audius/core:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/core:${TAG:-current}
     restart: unless-stopped
     ports:
       - "26656:26656" # CometBFT P2P Server
@@ -131,7 +131,7 @@ services:
       timeout: 5s
 
   relay:
-    image: audius/relay:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/relay:${TAG:-current}
     container_name: relay
     <<: *extra-hosts
     restart: unless-stopped
@@ -151,7 +151,7 @@ services:
       driver: json-file
 
   solana-relay:
-    image: audius/solana-relay:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/solana-relay:${TAG:-current}
     container_name: solana-relay
     <<: *extra-hosts
     restart: unless-stopped
@@ -171,7 +171,7 @@ services:
       driver: json-file
 
   openresty:
-    image: audius/discovery-provider-openresty:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/discovery-provider-openresty:${TAG:-current}
     container_name: openresty
     <<: *extra-hosts
     restart: unless-stopped
@@ -184,7 +184,7 @@ services:
 
   backend:
     container_name: server
-    image: audius/discovery-provider:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/discovery-provider:${TAG:-current}
     <<: *extra-hosts
     restart: always
     mem_limit: ${SERVER_MEM_LIMIT:-5000000000}
@@ -217,7 +217,7 @@ services:
 
   indexer:
     container_name: indexer
-    image: audius/discovery-provider:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/discovery-provider:${TAG:-current}
     <<: *extra-hosts
     restart: always
     mem_limit: ${INDEXER_MEM_LIMIT:-5000000000}
@@ -259,7 +259,7 @@ services:
       - discovery-provider-network
 
   seed:
-    image: audius/discovery-provider:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/discovery-provider:${TAG:-current}
     command: bash /usr/share/seed.sh ${NETWORK:-prod}
     env_file:
       - ${NETWORK:-prod}.env
@@ -296,7 +296,7 @@ services:
       - ../auto-upgrade.log:/auto-upgrade.log
 
   comms:
-    image: audius/comms:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/comms:${TAG:-current}
     container_name: comms
     command: comms discovery
     <<: *extra-hosts
@@ -315,7 +315,7 @@ services:
       driver: json-file
 
   es-indexer:
-    image: audius/es-indexer:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/es-indexer:${TAG:-current}
     container_name: es-indexer
     restart: unless-stopped
     networks:
@@ -332,7 +332,7 @@ services:
       driver: json-file
 
   trpc:
-    image: audius/trpc:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/trpc:${TAG:-current}
     container_name: trpc
     restart: unless-stopped
     networks:
@@ -427,7 +427,7 @@ services:
   # plugins
 
   notifications:
-    image: audius/discovery-provider-notifications:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/discovery-provider-notifications:${TAG:-current}
     container_name: notifications
     restart: unless-stopped
     networks:
@@ -446,7 +446,7 @@ services:
       - notifications
 
   sla-auditor:
-    image: audius/sla-auditor:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/sla-auditor:${TAG:-current}
     container_name: sla-auditor
     restart: unless-stopped
     networks:
@@ -465,7 +465,7 @@ services:
       driver: json-file
 
   crm:
-    image: audius/crm:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/crm:${TAG:-current}
     container_name: crm
     restart: unless-stopped
     networks:
@@ -484,7 +484,7 @@ services:
       driver: json-file
 
   backfill-audio-analyses:
-    image: audius/backfill-audio-analyses:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/backfill-audio-analyses:${TAG:-current}
     container_name: backfill-audio-analyses
     restart: on-failure
     networks:
@@ -501,7 +501,7 @@ services:
       driver: json-file
 
   trending-challenge-rewards:
-    image: audius/trending-challenge-rewards:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/trending-challenge-rewards:${TAG:-current}
     container_name: trending-challenge-rewards
     restart: unless-stopped
     networks:
@@ -541,7 +541,7 @@ services:
       driver: json-file
 
   mri:
-    image: audius/mri:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/mri:${TAG:-current}
     container_name: mri
     restart: unless-stopped
     networks:

--- a/identity-service/docker-compose.yml
+++ b/identity-service/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - identity-service-network
 
   backend:
-    image: audius/identity-service:${TAG:-f6a42ae06fd8e58d1d524cfdfdbc7953701f527d}
+    image: audius/identity-service:${TAG:-current}
     container_name: server
     <<: *extra-hosts
     depends_on:


### PR DESCRIPTION
### Description

Releases are now handled without updating git sha, so any nodes that don't have a tag set (e.g. legacy nodes) will default to current.