### PR TITLE
Use pre-existing dir for comet persistent data

### DIFF
--- a/creator-node/docker-compose.yml
+++ b/creator-node/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     mem_limit: 1g
     cpus: 1
     volumes:
-      - /var/k8s/audius-core:/audius-core
+      - /var/k8s/bolt:/audius-core
     env_file:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}

--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     mem_limit: 1g
     cpus: 1
     volumes:
-      - /var/k8s/audius-core:/audius-core
+      - /var/k8s/bolt:/audius-core
     env_file:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}


### PR DESCRIPTION
`audius-ctl` is unable to create directories that do not already exist on the host.

for sake of ease, use a dir that exists on both node types ⚡ 

**TEST**

ran with the following audius-ctl config
```
network:
  deployOn: mainnet
nodes:
  <host>:
    ...
    version: endl/corev
```

results in
```
$ ssh <host>
$ ls /var/k8s/bolt/
audius-mainnet-test2  uptime.db
```