### PR TITLE
Touch auto upgrade logfile on launch

### DIFF
--- a/audius-cli
+++ b/audius-cli
@@ -401,6 +401,13 @@ def launch(ctx, service, seed, auto_seed, chain, yes):
 
     lock(ctx, "docker")
 
+    log_file = ctx.obj["manifests_path"] / "auto-upgrade.log"
+    try:
+        # clear the previous auto-upgrade logs
+        open(log_file, "w").close()
+    except Exception as e:
+        print(f"Error while clearing the log file: {e}")
+
     try:
         ctx.invoke(check_config, service=service)
     except SystemExit:


### PR DESCRIPTION
### Description

Possible that this file doesn't exist if the launch runs before a first auto upgrade.

Note sure why we haven't seen this before. Maybe a docker change?