### PR TITLE
Set core stage loglevel default to info

### DIFF
--- a/creator-node/stage.env
+++ b/creator-node/stage.env
@@ -51,3 +51,4 @@ rewardsManagerTokenPda=HJQj8P47BdA7ugjQEn45LaESYrxhiZDygmukt8iumFZJ
 
 # Core
 audius_core_root_dir=/audius-core
+audius_core_log_level=info

--- a/discovery-provider/stage.env
+++ b/discovery-provider/stage.env
@@ -89,3 +89,4 @@ audius_ddex_apps='49d5e13d355709b615b7cce7369174fb240b6b39,574a8f89a3009591329a6
 
 # Core
 audius_core_root_dir=/audius-core
+audius_core_log_level=info


### PR DESCRIPTION
Related: https://github.com/AudiusProject/audius-protocol/pull/10589

```
# end result for core logs

foundation: info
sps: error
dev: debug
stage: info
```

