### PR TITLE
Use audiusd in core only mode for full discovery nodes

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -59,25 +59,63 @@ services:
     profiles:
       - discovery
 
-  core:
-    container_name: core
-    image: audius/core:${TAG:-current}
+  # core:
+  #   container_name: core
+  #   image: audius/core:${TAG:-current}
+  #   restart: unless-stopped
+  #   ports:
+  #     - "26656:26656" # CometBFT P2P Server
+  #     - "26657:26657" # CometBFT RPC Server
+  #     - "26659:26659" # Console UI
+  #     - "50051:50051" # Core GRPC Server
+  #   mem_limit: 2g
+  #   cpus: 2
+  #   volumes:
+  #     - /var/k8s/bolt:/audius-core
+  #   env_file:
+  #     - ${NETWORK:-prod}.env
+  #     - ${OVERRIDE_PATH:-override.env}
+  #   networks:
+  #     - discovery-provider-network
+  #   pull_policy: always
+  #   logging:
+  #     options:
+  #       max-size: 10m
+  #       max-file: 3
+  #       mode: non-blocking
+  #       max-buffer-size: 100m
+  #     driver: json-file
+  #   depends_on:
+  #     db:
+  #       condition: service_healthy
+  #   profiles:
+  #     - discovery
+  
+  audiusd-core:
+    image: audius/audiusd:${TAG:-current}
+    container_name: audiusd
+    pull_policy: always
+    <<: *extra-hosts
     restart: unless-stopped
+    networks:
+      - discovery-provider-network
     ports:
-      - "26656:26656" # CometBFT P2P Server
-      - "26657:26657" # CometBFT RPC Server
-      - "26659:26659" # Console UI
-      - "50051:50051" # Core GRPC Server
-    mem_limit: 2g
-    cpus: 2
-    volumes:
-      - /var/k8s/bolt:/audius-core
+      - '26656:26656'                    # cometBFT P2P server
+      - '26657:26657'                    # cometBFT RPC server
+      - '26660:26659'                    # console UI
+      - '50051:50051'                    # core GRPC server
+      - "${AUDIUSD_HTTP_PORT:-26659}:80" # proxy to core
     env_file:
       - ${NETWORK:-prod}.env
       - ${OVERRIDE_PATH:-override.env}
-    networks:
-      - discovery-provider-network
-    pull_policy: always
+    environment:
+      - LOGSPOUT=ignore
+      - AUDIUSD_STORAGE_ENABLED=false
+      - AUDIUSD_POSTGRES_ENABLED=false
+      - AUDIUSD_UPTIME_ENABLED=false
+      - audius_core_root_dir=/audius-core
+      # - audius_db_url=postgresql://postgres:postgres@localhost:5432/audius_discovery
+      # - audius_db_url_read_replica=postgresql://postgres:postgres@localhost:5432/audius_discovery
     logging:
       options:
         max-size: 10m
@@ -85,9 +123,15 @@ services:
         mode: non-blocking
         max-buffer-size: 100m
       driver: json-file
-    depends_on:
-      db:
-        condition: service_healthy
+    volumes:
+      - /var/k8s/bolt:/bolt
+      - /var/k8s/bolt:/audius-core
+      - /var/k8s/discovery-provider-db:/data/postgres
+    deploy:
+      resources:
+        limits:
+          cpus: '6.0'
+          memory: '14G'
     profiles:
       - discovery
 


### PR DESCRIPTION
Removes need for a discreet `core` container and the build overhead that comes with that.

**TEST**

Untested