### PR TITLE
Fix init round gas price and idempotency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ ddex/mongo-keyfile
 # old utilities
 sp-utilities/node_modules/*
 utilities/node_modules/*
+utilities/claim/wormholeTransactions.txt
 
 ddex/data


### PR DESCRIPTION
### Description

Two things:
- Gas price not passed through or calculated. Recent eth craziness made this start causing TXs to not get mined and pile up. Had to manually set nonce, etc. to clear and then set this gasPrice to get things through
- Currently the wh redemption is not idempotent because it re-uses the tx has from the eth tx part. If, for whatever reason, the wormhole thing fails, that tx hash gets lost. Instead, memoize the tx hash in a file and keep that around to store failed tx for future retries. It would have been nice to just use the eth rpc to get the tx hash, but it's a big pain to look this up and there are no good log emits in that contract itself. We'd have to crawl up block by blocking looking for the right tx. PITA! Anyway, this works well


### Testing

```
FEE_PAYER_SECRET_KEY=<fee-payer-secret-key> \
npm run claim:init-round --transfer-rewards-to-solana -- <eth-fee-payer-private-key> \
        --eth-rpc-endpoint=<eth-rpc-endpoint> \
        --solana-rpc-endpoint=<solana-rpc-endpoint>
```