### PR TITLE
Accept direct requests via caddy

### DIFF
--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -1,15 +1,31 @@
-{$audius_discprov_url}
-
-{$CADDY_TLS}
-
-encode zstd gzip
-
-@comms {
-    path /comms*
-    expression "{$NO_COMMS}" == ""
+# Handle domain name with HTTPS
+{$audius_discprov_url} {
+    {$CADDY_TLS}
+    
+    encode zstd gzip
+    
+    @comms {
+        path /comms*
+        expression "{$NO_COMMS}" == ""
+    }
+    reverse_proxy @comms comms:8925
+    
+    # defaults to openresty:5000
+    header X-Forwarded-Proto {scheme}
+    reverse_proxy {$ROOT_HOST:"openresty:5000"}
 }
-reverse_proxy @comms comms:8925
 
-# defaults to openresty:5000
-header X-Forwarded-Proto {scheme}
-reverse_proxy {$ROOT_HOST:"openresty:5000"}
+# Handle IP address with HTTP - explicitly bind to all interfaces
+:80 {
+    encode zstd gzip
+    
+    @comms {
+        path /comms*
+        expression "{$NO_COMMS}" == ""
+    }
+    reverse_proxy @comms comms:8925
+    
+    # defaults to openresty:5000
+    header X-Forwarded-Proto {scheme}
+    reverse_proxy {$ROOT_HOST:"openresty:5000"}
+}


### PR DESCRIPTION
### Description

As part of creating a single lb to manage our discovery instances, I want to make fetching via ip also work in conjunction with the https hostname.

This is because we cannot have a cloudflare worker redirect requests to other cloudflare cached endpoints.
