### PR TITLE
Add unproxied host option

### DIFF
--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -17,8 +17,6 @@
 
 # Add a second HTTPS domain for unproxied requests
 {$audius_discprov_url_unproxied} {
-    {$CADDY_TLS}
-    
     encode zstd gzip
     
     @comms {

--- a/discovery-provider/Caddyfile
+++ b/discovery-provider/Caddyfile
@@ -15,6 +15,23 @@
     reverse_proxy {$ROOT_HOST:"openresty:5000"}
 }
 
+# Add a second HTTPS domain for unproxied requests
+{$audius_discprov_url_unproxied} {
+    {$CADDY_TLS}
+    
+    encode zstd gzip
+    
+    @comms {
+        path /comms*
+        expression "{$NO_COMMS}" == ""
+    }
+    reverse_proxy @comms comms:8925
+
+    # defaults to openresty:5000
+    header X-Forwarded-Proto {scheme}
+    reverse_proxy {$ROOT_HOST:"openresty:5000"}
+}
+
 # Handle IP address with HTTP - explicitly bind to all interfaces
 :80 {
     encode zstd gzip


### PR DESCRIPTION
### Description

Caddy should ignore this if `audius_discprov_url_unproxied` doesn't resolve