### PR TITLE
Drop staking service

### DIFF
--- a/discovery-provider/docker-compose.yml
+++ b/discovery-provider/docker-compose.yml
@@ -395,25 +395,6 @@ services:
         max-buffer-size: 100m
       driver: json-file
 
-  staking:
-    image: audius/staking:${TAG:-current}
-    container_name: staking
-    restart: unless-stopped
-    networks:
-      - discovery-provider-network
-    env_file:
-      - ${NETWORK:-prod}.env
-      - ${OVERRIDE_PATH:-override.env}
-    profiles:
-      - staking
-    logging:
-      options:
-        max-size: 10m
-        max-file: 3
-        mode: non-blocking
-        max-buffer-size: 100m
-      driver: json-file
-
   metabase:
     image: metabase/metabase:v0.48.0
     container_name: metabase


### PR DESCRIPTION
## Summary
- Removes the `staking` service from `discovery-provider/docker-compose.yml`.
- Staking has migrated to a standalone k8s deployment at `staking.audius.engineering` (see `audius-k8s/Pulumi.prod-staking.yaml`), so the per-discovery-node container is no longer needed.
- The nginx `/plugins/<upstream>/` rule in `apps/packages/discovery-provider/nginx_conf/nginx_container.conf` is unaffected — it serves other plugins and just won't resolve `staking` anymore (harmless).

## Test plan
- [ ] Confirm new k8s service is healthy: `curl https://staking.audius.engineering/health` (verified 200 at PR creation time).
- [ ] Confirm UptimeRobot monitors have been flipped to the new host before merging (AudiusProject/uptime-robot#TBD).
- [ ] No SP is depending on running `audius-compose up --profile staking` locally for this service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)